### PR TITLE
Automatically configure Laravel for Lambda

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -3,7 +3,6 @@
     <arg name="basepath" value="."/>
 
     <file>src</file>
-    <file>tests</file>
 
     <rule ref="HardMode"/>
 </ruleset>

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ In any case, it is recommended to [first learn about serverless, AWS Lambda and 
 composer require bref/laravel-bridge
 ```
 
+The `Bref\LaravelBridge\BrefServiceProvider` service provider will be registered automatically.
+
 ## Laravel Queues with SQS
 
 **These instructions apply to Laravel 7.**

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The `Bref\LaravelBridge\BrefServiceProvider` service provider will be registered
 You can now create a default `serverless.yml` at the root of your project by running:
 
 ```bash
-php artisan vendor:publish --tag=config
+php artisan vendor:publish --tag=serverless-config
 ```
 
 ## Laravel Queues with SQS

--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ composer require bref/laravel-bridge
 
 The `Bref\LaravelBridge\BrefServiceProvider` service provider will be registered automatically.
 
+You can now create a default `serverless.yml` at the root of your project by running:
+
+```bash
+php artisan vendor:publish --tag=config
+```
+
 ## Laravel Queues with SQS
 
 **These instructions apply to Laravel 7.**

--- a/composer.json
+++ b/composer.json
@@ -29,5 +29,12 @@
         "phpstan/phpstan": "^0.12.0",
         "symfony/filesystem": "^5.0",
         "symfony/process": "^5.0"
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Bref\\LaravelBridge\\BrefServiceProvider"
+            ]
+        }
     }
 }

--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -1,0 +1,40 @@
+service: laravel
+
+provider:
+    name: aws
+    # The AWS region in which to deploy (us-east-1 is the default)
+    region: us-east-1
+    # The stage of the application, e.g. dev, production, staging… ('dev' is the default)
+    stage: dev
+    runtime: provided
+
+package:
+    # Directories to exclude from deployment
+    exclude:
+        - node_modules/**
+        - public/storage
+        - resources/assets/**
+        - storage/**
+        - tests/**
+
+functions:
+    # This function runs the Laravel website/API
+    web:
+        handler: public/index.php
+        timeout: 28 # in seconds (API Gateway has a timeout of 29 seconds)
+        layers:
+            - ${bref:layer.php-74-fpm}
+        events:
+            -   http: 'ANY /'
+            -   http: 'ANY /{proxy+}'
+    # This function lets us run artisan commands in Lambda
+    artisan:
+        handler: artisan
+        timeout: 120 # in seconds
+        layers:
+            - ${bref:layer.php-74} # PHP
+            - ${bref:layer.console} # The "console" layer
+
+plugins:
+    # We need to include the Bref plugin
+    - ./vendor/bref/bref

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -2,4 +2,3 @@ parameters:
   level: 5
   paths:
     - src
-    - tests

--- a/src/BrefServiceProvider.php
+++ b/src/BrefServiceProvider.php
@@ -48,7 +48,8 @@ class BrefServiceProvider extends ServiceProvider
         Config::set('view.compiled', '/tmp/storage/framework/views');
 
         // Allow all proxies because AWS Lambda runs behind API Gateway
-        Config::set('trustedproxy.proxies', '*');
+        // See https://github.com/fideloper/TrustedProxy/issues/115#issuecomment-503596621
+        Config::set('trustedproxy.proxies', ['0.0.0.0/0', '2000:0:0:0:0:0:0:0/3']);
 
         // Sessions cannot be stored to files, so we use cookies by default instead
         $sessionDriver = Config::get('session.driver');

--- a/src/BrefServiceProvider.php
+++ b/src/BrefServiceProvider.php
@@ -1,0 +1,59 @@
+<?php declare(strict_types=1);
+
+namespace Bref\LaravelBridge;
+
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\ServiceProvider;
+use RuntimeException;
+
+class BrefServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        // Make sure the directory for compiled views exist
+        $compiledViewDirectory = Config::get('view.compiled');
+        if (! is_dir($compiledViewDirectory)) {
+            // The directory doesn't exist: let's create it, else Laravel will not create it automatically
+            // and will fail with an error
+            if (! mkdir($compiledViewDirectory, 0755, true) && ! is_dir($compiledViewDirectory)) {
+                throw new RuntimeException(sprintf('Directory "%s" cannot be created', $compiledViewDirectory));
+            }
+        }
+    }
+
+    public function register(): void
+    {
+        $isRunningInLambda = isset($_SERVER['LAMBDA_TASK_ROOT']);
+
+        // Laravel Mix URL for assets stored on S3
+        $mixAssetUrl = $_SERVER['MIX_ASSET_URL'];
+        if ($mixAssetUrl) {
+            Config::set('app.mix_url', $mixAssetUrl);
+        }
+
+        // The rest below is specific to AWS Lambda
+        if (! $isRunningInLambda) {
+            return;
+        }
+
+        // We change Laravel's default log destination to stderr
+        // (if it hasn't been changed by the user)
+        $logDriver = Config::get('logging.default');
+        if ($logDriver === 'stack' && ! isset($_SERVER['LOG_CHANNEL'])) {
+            Config::set('logging.default', 'stderr');
+        }
+
+        // Store compiled views in `/tmp` because they are generated at runtime
+        // and `/tmp` is the only writable directory on Lambda
+        Config::set('view.compiled', '/tmp/storage/framework/views');
+
+        // Allow all proxies because AWS Lambda runs behind API Gateway
+        Config::set('trustedproxy.proxies', '*');
+
+        // Sessions cannot be stored to files, so we use cookies by default instead
+        $sessionDriver = Config::get('session.driver');
+        if ($sessionDriver === 'file') {
+            Config::set('session.driver', 'cookie');
+        }
+    }
+}

--- a/src/BrefServiceProvider.php
+++ b/src/BrefServiceProvider.php
@@ -21,7 +21,7 @@ class BrefServiceProvider extends ServiceProvider
         }
 
         $this->publishes([
-            __DIR__.'/../config/serverless.yml' => base_path('serverless.yml')
+            __DIR__ . '/../config/serverless.yml' => base_path('serverless.yml'),
         ], 'config');
     }
 

--- a/src/BrefServiceProvider.php
+++ b/src/BrefServiceProvider.php
@@ -26,7 +26,7 @@ class BrefServiceProvider extends ServiceProvider
         $isRunningInLambda = isset($_SERVER['LAMBDA_TASK_ROOT']);
 
         // Laravel Mix URL for assets stored on S3
-        $mixAssetUrl = $_SERVER['MIX_ASSET_URL'];
+        $mixAssetUrl = $_SERVER['MIX_ASSET_URL'] ?? null;
         if ($mixAssetUrl) {
             Config::set('app.mix_url', $mixAssetUrl);
         }

--- a/src/BrefServiceProvider.php
+++ b/src/BrefServiceProvider.php
@@ -19,6 +19,10 @@ class BrefServiceProvider extends ServiceProvider
                 throw new RuntimeException(sprintf('Directory "%s" cannot be created', $compiledViewDirectory));
             }
         }
+
+        $this->publishes([
+            __DIR__.'/../config/serverless.yml' => base_path('serverless.yml')
+        ], 'config');
     }
 
     public function register(): void

--- a/src/BrefServiceProvider.php
+++ b/src/BrefServiceProvider.php
@@ -21,7 +21,7 @@ class BrefServiceProvider extends ServiceProvider
         }
 
         $this->publishes([
-            __DIR__ . '/../config/serverless.yml' => base_path('serverless.yml'),
+            __DIR__ . '/../config/serverless.yml' => $this->app->basePath('serverless.yml'),
         ], 'config');
     }
 

--- a/src/BrefServiceProvider.php
+++ b/src/BrefServiceProvider.php
@@ -22,7 +22,7 @@ class BrefServiceProvider extends ServiceProvider
 
         $this->publishes([
             __DIR__ . '/../config/serverless.yml' => $this->app->basePath('serverless.yml'),
-        ], 'config');
+        ], 'serverless-config');
     }
 
     public function register(): void

--- a/src/Queue/LaravelSqsHandler.php
+++ b/src/Queue/LaravelSqsHandler.php
@@ -73,7 +73,7 @@ class LaravelSqsHandler extends SqsHandler
     /**
      * @see \Illuminate\Queue\Worker::process()
      */
-    private function process($connectionName, SqsJob $job): void
+    private function process(string $connectionName, SqsJob $job): void
     {
         try {
             // First we will raise the before job event and determine if the job has already ran
@@ -101,7 +101,8 @@ class LaravelSqsHandler extends SqsHandler
     private function raiseBeforeJobEvent(string $connectionName, SqsJob $job): void
     {
         $this->events->dispatch(new JobProcessing(
-            $connectionName, $job
+            $connectionName,
+            $job
         ));
     }
 
@@ -111,7 +112,8 @@ class LaravelSqsHandler extends SqsHandler
     private function raiseAfterJobEvent(string $connectionName, SqsJob $job): void
     {
         $this->events->dispatch(new JobProcessed(
-            $connectionName, $job
+            $connectionName,
+            $job
         ));
     }
 
@@ -121,7 +123,9 @@ class LaravelSqsHandler extends SqsHandler
     private function raiseExceptionOccurredJobEvent(string $connectionName, SqsJob $job, Throwable $e): void
     {
         $this->events->dispatch(new JobExceptionOccurred(
-            $connectionName, $job, $e
+            $connectionName,
+            $job,
+            $e
         ));
     }
 }

--- a/tests/App/config/app.php
+++ b/tests/App/config/app.php
@@ -165,6 +165,7 @@ return [
         /*
          * Package Service Providers...
          */
+        Bref\LaravelBridge\BrefServiceProvider::class,
 
         /*
          * Application Service Providers...


### PR DESCRIPTION
This PR adds a service provider that will automatically configure Laravel.

This makes it much easier to deploy Laravel on Lambda with Bref:

- `composer require bref/laravel-bridge`
- `php artisan vendor:publish --tag=config` to create `serverless.yml`
- `serverless deploy`