### PR TITLE
Add default SQS connection and queue

### DIFF
--- a/src/Queue/LaravelSqsHandler.php
+++ b/src/Queue/LaravelSqsHandler.php
@@ -32,7 +32,7 @@ class LaravelSqsHandler extends SqsHandler
     /** @var string */
     private $queue;
 
-    public function __construct(Container $container, Dispatcher $events, string $connection, string $queue)
+    public function __construct(Container $container, Dispatcher $events, string $connection = 'sqs', ?string $queue = null)
     {
         $this->container = $container;
         /** @var QueueManager $queueManager */
@@ -44,7 +44,7 @@ class LaravelSqsHandler extends SqsHandler
         $this->sqs = $queueConnector->getSqs();
         $this->events = $events;
         $this->connectionName = $connection;
-        $this->queue = $queue;
+        $this->queue = $queueConnector->getQueue($queue);
     }
 
     public function handleSqs(SqsEvent $event, Context $context): void


### PR DESCRIPTION
Previously, I have to add additional environment variables to get SQS working in my `worker.php` function.

```php
<?php

use Bref\LaravelBridge\Queue\LaravelSqsHandler;
use Illuminate\Foundation\Application;
use Illuminate\Support\Str;

require __DIR__ . '/../vendor/autoload.php';
/** @var Application $app */
$app = require __DIR__ . '/../bootstrap/app.php';

$kernel = $app->make(Illuminate\Contracts\Console\Kernel::class);
$kernel->bootstrap();

$prefix = getenv('SQS_PREFIX');
$suffix = getenv('SQS_SUFFIX');
$queue = getenv('SQS_QUEUE');

$url = filter_var($queue, FILTER_VALIDATE_URL) === false
    ? rtrim($prefix, '/') . '/' . Str::finish($queue, $suffix)
    : $queue;

return $app->makeWith(LaravelSqsHandler::class, [
    'connection' => 'sqs',
    'queue' => $url,
]);
```

With this PR, my `worker.php` can look like this:

```php
// worker.php

<?php

require __DIR__ . '/base.php';

return Laravel::make(Bref\LaravelBridge\Queue\LaravelSqsHandler::class);
```

```php
// base.php

<?php

require __DIR__ . '/../vendor/autoload.php';

use Illuminate\Foundation\Application;

class Laravel {

    public static function make($abstract, array $parameters = [])
    {
        /** @var Application $app */
        $app = require __DIR__ . '/../bootstrap/app.php';

        $kernel = $app->make(\Illuminate\Contracts\Console\Kernel::class);
        $kernel->bootstrap();

        return $app->make($abstract, $parameters);
    }
}
```
