### PR TITLE
Allow Lambda invocation context to be injected

### DIFF
--- a/src/Queue/LaravelSqsHandler.php
+++ b/src/Queue/LaravelSqsHandler.php
@@ -49,6 +49,10 @@ class LaravelSqsHandler extends SqsHandler
 
     public function handleSqs(SqsEvent $event, Context $context): void
     {
+        $this->container->singleton(Context::class, function () use ($context) {
+            return $context;
+        });
+
         foreach ($event->getRecords() as $sqsRecord) {
             $recordData = $sqsRecord->toArray();
             $jobData = [


### PR DESCRIPTION
With this PR, I can inject the Lambda invocation context into jobs.

```php
<?php

namespace App\Jobs;

use Bref\Context\Context;
use Illuminate\Bus\Queueable;
use Illuminate\Contracts\Queue\ShouldQueue;
use Illuminate\Foundation\Bus\Dispatchable;
use Illuminate\Queue\InteractsWithQueue;
use Illuminate\Queue\SerializesModels;

class LambdaTest implements ShouldQueue
{
    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;

    protected $work = 0;

    public function handle(Context $context)
    {
        $shouldPause = false;

        while (!$this->isWorkDone() && !$shouldPause) {
            $this->doWork();

            // check deadline
            $remaining = $context->getRemainingTimeInMillis();
            $shouldPause = $remaining < 1500;
        }

        if (!$this->isWorkDone()) {
            // pause and requeue
        } else {
            // cleanup
        }
    }

    protected function doWork()
    {
        $this->work++;
    }

    protected function isWorkDone()
    {
        return $this->work >= 100;
    }
}

```