### PR TITLE
Send SQS worker exceptions to defined log channel

### DIFF
--- a/src/Queue/LaravelSqsHandler.php
+++ b/src/Queue/LaravelSqsHandler.php
@@ -125,7 +125,6 @@ class LaravelSqsHandler extends SqsHandler
     {
         // Before bref handles the exception, we send it to the laravel log driver to allow
         // worker exceptions to be pushed to the defined log channel, aswell as stderr.
-        // The report helper
         Container::getInstance()->make(ExceptionHandler::class, [])->report($e);
 
         $this->events->dispatch(new JobExceptionOccurred(

--- a/src/Queue/LaravelSqsHandler.php
+++ b/src/Queue/LaravelSqsHandler.php
@@ -122,6 +122,10 @@ class LaravelSqsHandler extends SqsHandler
      */
     private function raiseExceptionOccurredJobEvent(string $connectionName, SqsJob $job, Throwable $e): void
     {
+        // Before bref handles the exception, we send it to the laravel log driver to allow
+        // worker exceptions to be pushed to the defined log channel, as well as stderr.
+        report($e);
+
         $this->events->dispatch(new JobExceptionOccurred(
             $connectionName,
             $job,

--- a/src/Queue/LaravelSqsHandler.php
+++ b/src/Queue/LaravelSqsHandler.php
@@ -92,11 +92,11 @@ class LaravelSqsHandler extends SqsHandler
 
             $this->raiseAfterJobEvent($connectionName, $job);
         } catch (Throwable $e) {
-            // Report exception to defined log channel
-            $this->exceptions->report($e);
-
             // Fire off an exception event
             $this->raiseExceptionOccurredJobEvent($connectionName, $job, $e);
+
+            // Report exception to defined log channel
+            $this->exceptions->report($e);
 
             // Rethrow the exception to let SQS handle it
             throw $e;

--- a/src/Queue/LaravelSqsHandler.php
+++ b/src/Queue/LaravelSqsHandler.php
@@ -7,6 +7,7 @@ use Bref\Context\Context;
 use Bref\Event\Sqs\SqsEvent;
 use Bref\Event\Sqs\SqsHandler;
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Queue\Events\JobExceptionOccurred;
 use Illuminate\Queue\Events\JobProcessed;
@@ -123,8 +124,9 @@ class LaravelSqsHandler extends SqsHandler
     private function raiseExceptionOccurredJobEvent(string $connectionName, SqsJob $job, Throwable $e): void
     {
         // Before bref handles the exception, we send it to the laravel log driver to allow
-        // worker exceptions to be pushed to the defined log channel, as well as stderr.
-        report($e);
+        // worker exceptions to be pushed to the defined log channel, aswell as stderr.
+        // The report helper
+        Container::getInstance()->make(ExceptionHandler::class, [])->report($e);
 
         $this->events->dispatch(new JobExceptionOccurred(
             $connectionName,


### PR DESCRIPTION
Using the report helper, we can push exceptions to our defined log channel before bref handles the exception.

<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->
Ideally, if a job fails, exceptions would be pushed to our desired log driver. Cloudwatch logs aren't the easiest to use, especially for people who aren't in the know on how bref is deployed. So we use flare to keep visibility on errors consistent across all of our laravel apps. Currently, the bref SQS queue handler doesn't report failed jobs to the defined log channel, this is confusing when web functions do.