### PR TITLE
Added Bref 1.0 version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^7.3",
         "ext-json": "*",
-        "bref/bref": "~0.5.20",
+        "bref/bref": "~0.5.20|^1.0.0",
         "illuminate/queue": "^6.0|^7.0|^8.0",
         "illuminate/support": "^6.0|^7.0|^8.0",
         "aws/aws-sdk-php": "^3.134"


### PR DESCRIPTION
Bref 1.0 was released & while trying to upgrade i found that laravel-bridge was missing support due to it's version constraint. I can't think of anything that isn't compatible with laravel-bridge? So this just adds support for it. Not sure if this version constraint is too wide.