### PR TITLE
Store job attempt in job payload and refactor worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,9 @@ Here is a complete example with `serverless.yml` that creates the queue, as well
 provider:
     ...
     environment:
-        APP_ENV: production
-        SQS_QUEUE: !Ref AlertQueue
+      APP_ENV: production
+      QUEUE_CONNECTION: sqs
+      SQS_QUEUE: !Ref AlertQueue
         # If you create the queue manually, the `SQS_QUEUE` variable can be defined like this:
         # SQS_QUEUE: https://sqs.us-east-1.amazonaws.com/your-account-id/my-queue
     iamRoleStatements:

--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ Here is a complete example with `serverless.yml` that creates the queue, as well
 provider:
     ...
     environment:
-      APP_ENV: production
-      QUEUE_CONNECTION: sqs
-      SQS_QUEUE: !Ref AlertQueue
+        APP_ENV: production
+        QUEUE_CONNECTION: sqs
+        SQS_QUEUE: !Ref AlertQueue
         # If you create the queue manually, the `SQS_QUEUE` variable can be defined like this:
         # SQS_QUEUE: https://sqs.us-east-1.amazonaws.com/your-account-id/my-queue
     iamRoleStatements:

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "bref/bref": "^1.0",
         "illuminate/queue": "^6.0|^7.0|^8.0",
         "illuminate/support": "^6.0|^7.0|^8.0",
-        "aws/aws-sdk-php": "^3.134"
+        "aws/aws-sdk-php": "^3.134",
+        "ext-pcntl": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,7 @@
         "bref/bref": "^1.0",
         "illuminate/queue": "^6.0|^7.0|^8.0",
         "illuminate/support": "^6.0|^7.0|^8.0",
-        "aws/aws-sdk-php": "^3.134",
-        "ext-pcntl": "*"
+        "aws/aws-sdk-php": "^3.134"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",

--- a/src/Queue/LaravelSqsHandler.php
+++ b/src/Queue/LaravelSqsHandler.php
@@ -7,8 +7,6 @@ use Bref\Context\Context;
 use Bref\Event\Sqs\SqsEvent;
 use Bref\Event\Sqs\SqsHandler;
 use Illuminate\Container\Container;
-use Illuminate\Contracts\Debug\ExceptionHandler;
-use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Queue\QueueManager;
 use Illuminate\Queue\SqsQueue;
 use Illuminate\Queue\WorkerOptions;
@@ -18,20 +16,12 @@ use Illuminate\Queue\WorkerOptions;
  */
 class LaravelSqsHandler extends SqsHandler
 {
-    /** @var Container */
-    private $container;
-    /** @var SqsClient */
-    private $sqs;
-    /** @var Dispatcher */
-    private $events;
-    /** @var ExceptionHandler */
-    private $exceptions;
-    /** @var string */
-    private $connectionName;
-    /** @var string */
-    private $queue;
+    private Container $container;
+    private SqsClient $sqs;
+    private string $connectionName;
+    private string $queue;
 
-    public function __construct(Container $container, Dispatcher $events, ExceptionHandler $exceptions, string $connection, string $queue)
+    public function __construct(Container $container, string $connection, string $queue)
     {
         $this->container = $container;
         $queueManager = $container->get('queue');
@@ -41,20 +31,19 @@ class LaravelSqsHandler extends SqsHandler
             throw new \RuntimeException("The '$connection' connection is not a SQS connection in the Laravel config");
         }
         $this->sqs = $queueConnector->getSqs();
-        $this->events = $events;
-        $this->exceptions = $exceptions;
         $this->connectionName = $connection;
         $this->queue = $queue;
     }
 
     public function handleSqs(SqsEvent $event, Context $context): void
     {
-        /** @var Worker $worker */
         $worker = $this->container->makeWith(Worker::class, [
             'isDownForMaintenance' => function () {
                 return false;
             },
         ]);
+
+        \assert($worker instanceof Worker);
 
         foreach ($event->getRecords() as $sqsRecord) {
             $message = $this->normalizeMessage($sqsRecord->toArray());

--- a/src/Queue/LaravelSqsHandler.php
+++ b/src/Queue/LaravelSqsHandler.php
@@ -16,10 +16,17 @@ use Illuminate\Queue\WorkerOptions;
  */
 class LaravelSqsHandler extends SqsHandler
 {
-    private Container $container;
-    private SqsClient $sqs;
-    private string $connectionName;
-    private string $queue;
+    /** @var Container $container */
+    private $container;
+
+    /** @var SqsClient */
+    private $sqs;
+
+    /** @var string */
+    private $connectionName;
+
+    /** @var string */
+    private $queue;
 
     public function __construct(Container $container, string $connection, string $queue)
     {
@@ -80,15 +87,20 @@ class LaravelSqsHandler extends SqsHandler
 
     protected function getWorkerOptions(): WorkerOptions
     {
-        return new WorkerOptions(
-            'default',
+        $options = [
             0,
-            512,
+            $memory = 512,
             0,
-            0,
+            $sleep = 0,
             0,
             false,
-            false
-        );
+            false,
+        ];
+
+        if (property_exists(WorkerOptions::class, 'name')) {
+            $options = array_merge(['default'], $options);
+        }
+
+        return new WorkerOptions(...$options);
     }
 }

--- a/src/Queue/LaravelSqsHandler.php
+++ b/src/Queue/LaravelSqsHandler.php
@@ -59,7 +59,7 @@ class LaravelSqsHandler extends SqsHandler
         foreach ($event->getRecords() as $sqsRecord) {
             $message = $this->normalizeMessage($sqsRecord->toArray());
 
-            $worker->runVaporJob(
+            $worker->runSqsJob(
                 $this->buildJob($message),
                 $this->connectionName,
                 $this->getWorkerOptions()

--- a/src/Queue/LaravelSqsHandler.php
+++ b/src/Queue/LaravelSqsHandler.php
@@ -88,13 +88,15 @@ class LaravelSqsHandler extends SqsHandler
     protected function getWorkerOptions(): WorkerOptions
     {
         $options = [
-            0,
+            $backoff = 0,
             $memory = 512,
-            0,
+            $timeout = 0,
             $sleep = 0,
-            0,
-            false,
-            false,
+            $maxTries = 0,
+            $force = false,
+            $stopWhenEmpty = false,
+            $maxJobs = 0,
+            $maxTime = 0,
         ];
 
         if (property_exists(WorkerOptions::class, 'name')) {

--- a/src/Queue/LaravelSqsHandler.php
+++ b/src/Queue/LaravelSqsHandler.php
@@ -12,7 +12,6 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Queue\Events\JobExceptionOccurred;
 use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Queue\Events\JobProcessing;
-use Illuminate\Queue\Jobs\SqsJob;
 use Illuminate\Queue\QueueManager;
 use Illuminate\Queue\SqsQueue;
 use Throwable;

--- a/src/Queue/SqsJob.php
+++ b/src/Queue/SqsJob.php
@@ -1,5 +1,4 @@
-<?php
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Bref\LaravelBridge\Queue;
 
@@ -8,10 +7,7 @@ use Illuminate\Queue\Jobs\SqsJob as LaravelSqsJob;
 class SqsJob extends LaravelSqsJob
 {
     /**
-     * Release the job back into the queue.
-     *
-     * @param int $delay
-     * @return void
+     * {@inheritDoc}
      */
     public function release($delay = 0)
     {
@@ -34,9 +30,7 @@ class SqsJob extends LaravelSqsJob
     }
 
     /**
-     * Get the number of times the job has been attempted.
-     *
-     * @return int
+     * {@inheritDoc}
      */
     public function attempts()
     {

--- a/src/Queue/SqsJob.php
+++ b/src/Queue/SqsJob.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Bref\LaravelBridge\Queue;
+
+use Illuminate\Queue\Jobs\SqsJob as LaravelSqsJob;
+
+class SqsJob extends LaravelSqsJob
+{
+    /**
+     * Release the job back into the queue.
+     *
+     * @param int $delay
+     * @return void
+     */
+    public function release($delay = 0)
+    {
+        $this->released = true;
+
+        $payload = $this->payload();
+
+        $payload['attempts'] = ($payload['attempts'] ?? 0) + 1;
+
+        $this->sqs->deleteMessage([
+            'QueueUrl' => $this->queue,
+            'ReceiptHandle' => $this->job['ReceiptHandle'],
+        ]);
+
+        $this->sqs->sendMessage([
+            'QueueUrl' => $this->queue,
+            'MessageBody' => json_encode($payload),
+            'DelaySeconds' => $this->secondsUntil($delay),
+        ]);
+    }
+
+    /**
+     * Get the number of times the job has been attempted.
+     *
+     * @return int
+     */
+    public function attempts()
+    {
+        return ($this->payload()['attempts'] ?? 0) + 1;
+    }
+}

--- a/src/Queue/SqsJob.php
+++ b/src/Queue/SqsJob.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Bref\LaravelBridge\Queue;
 

--- a/src/Queue/Worker.php
+++ b/src/Queue/Worker.php
@@ -1,5 +1,4 @@
-<?php
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Bref\LaravelBridge\Queue;
 

--- a/src/Queue/Worker.php
+++ b/src/Queue/Worker.php
@@ -2,20 +2,13 @@
 
 namespace Bref\LaravelBridge\Queue;
 
+use Illuminate\Contracts\Queue\Job;
 use Illuminate\Queue\Worker as LaravelWorker;
 use Illuminate\Queue\WorkerOptions;
 
 class Worker extends LaravelWorker
 {
-    /**
-     * Process the given job.
-     *
-     * @param \Illuminate\Contracts\Queue\Job $job
-     * @param string $connectionName
-     * @param \Illuminate\Queue\WorkerOptions $options
-     * @return void
-     */
-    public function runVaporJob($job, $connectionName, WorkerOptions $options)
+    public function runSqsJob(Job $job, string $connectionName, WorkerOptions $options): void
     {
         pcntl_async_signals(true);
 

--- a/src/Queue/Worker.php
+++ b/src/Queue/Worker.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Bref\LaravelBridge\Queue;
 

--- a/src/Queue/Worker.php
+++ b/src/Queue/Worker.php
@@ -10,18 +10,6 @@ class Worker extends LaravelWorker
 {
     public function runSqsJob(Job $job, string $connectionName, WorkerOptions $options): void
     {
-        pcntl_async_signals(true);
-
-        // pcntl_signal(SIGALRM, function () use ($job) {
-        //     throw new VaporJobTimedOutException($job->resolveName());
-        // });
-
-        pcntl_alarm(
-            max($this->timeoutForJob($job, $options), 0)
-        );
-
         $this->runJob($job, $connectionName, $options);
-
-        pcntl_alarm(0);
     }
 }

--- a/src/Queue/Worker.php
+++ b/src/Queue/Worker.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Bref\LaravelBridge\Queue;
+
+use Illuminate\Queue\Worker as LaravelWorker;
+use Illuminate\Queue\WorkerOptions;
+
+class Worker extends LaravelWorker
+{
+    /**
+     * Process the given job.
+     *
+     * @param \Illuminate\Contracts\Queue\Job $job
+     * @param string $connectionName
+     * @param \Illuminate\Queue\WorkerOptions $options
+     * @return void
+     */
+    public function runVaporJob($job, $connectionName, WorkerOptions $options)
+    {
+        pcntl_async_signals(true);
+
+        // pcntl_signal(SIGALRM, function () use ($job) {
+        //     throw new VaporJobTimedOutException($job->resolveName());
+        // });
+
+        pcntl_alarm(
+            max($this->timeoutForJob($job, $options), 0)
+        );
+
+        $this->runJob($job, $connectionName, $options);
+
+        pcntl_alarm(0);
+    }
+}


### PR DESCRIPTION
Fixes #14
Fixes #22

### Change 1: Store job attempt in job payload
`ApproximateReceiveCount` should not be used when processing SQS jobs in Lambda. See https://link.medium.com/uUkT2W9bTbb for more info. This PR adds functionality to store the current attempt on the job payload, so we don't have to depend on `ApproximateReceiveCount`.

One downside of this, is that because we can't update sqs messages, we always have to re-create a message when releasing it back onto the queue.

### Change 2: Refactor workers
This now uses the built-in worker to process jobs. This is more in line with how Laravel processes jobs for other drivers.

---
The code is 'backwards compatible' in the sense that the example `worker.php` remains identical. If you did not change that, all should continue working as usual.

The code is heavily inspired (and sometimes copied) from https://github.com/laravel/vapor-core/