### PR TITLE
Store job attempt in job payload & use Laravel's built-in queue worker

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -19,3 +19,27 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+
+vapor-core is distributed under the following license:
+
+The MIT License (MIT)
+
+Copyright (c) Taylor Otwell
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -85,8 +85,9 @@ Here is a complete example with `serverless.yml` that creates the queue, as well
 provider:
     ...
     environment:
-        APP_ENV: production
-        SQS_QUEUE: !Ref AlertQueue
+      APP_ENV: production
+      QUEUE_CONNECTION: sqs
+      SQS_QUEUE: !Ref AlertQueue
         # If you create the queue manually, the `SQS_QUEUE` variable can be defined like this:
         # SQS_QUEUE: https://sqs.us-east-1.amazonaws.com/your-account-id/my-queue
     iamRoleStatements:

--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ Here is a complete example with `serverless.yml` that creates the queue, as well
 provider:
     ...
     environment:
-      APP_ENV: production
-      QUEUE_CONNECTION: sqs
-      SQS_QUEUE: !Ref AlertQueue
+        APP_ENV: production
+        QUEUE_CONNECTION: sqs
+        SQS_QUEUE: !Ref AlertQueue
         # If you create the queue manually, the `SQS_QUEUE` variable can be defined like this:
         # SQS_QUEUE: https://sqs.us-east-1.amazonaws.com/your-account-id/my-queue
     iamRoleStatements:

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "bref/bref": "^1.0",
         "illuminate/queue": "^6.0|^7.0|^8.0",
         "illuminate/support": "^6.0|^7.0|^8.0",
-        "aws/aws-sdk-php": "^3.134"
+        "aws/aws-sdk-php": "^3.134",
+        "ext-pcntl": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",

--- a/composer.json
+++ b/composer.json
@@ -16,11 +16,11 @@
         }
     },
     "require": {
-        "php": ">=7.3",
+        "php": "^7.3|^8.0",
         "ext-json": "*",
         "bref/bref": "^1.0",
-        "illuminate/queue": "^6.0|^7.0|^8.0",
-        "illuminate/support": "^6.0|^7.0|^8.0",
+        "illuminate/queue": "^6.0|^7.0|^8.0|^9.0",
+        "illuminate/support": "^6.0|^7.0|^8.0|^9.0",
         "aws/aws-sdk-php": "^3.134"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,7 @@
         "bref/bref": "^1.0",
         "illuminate/queue": "^6.0|^7.0|^8.0",
         "illuminate/support": "^6.0|^7.0|^8.0",
-        "aws/aws-sdk-php": "^3.134",
-        "ext-pcntl": "*"
+        "aws/aws-sdk-php": "^3.134"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",

--- a/src/Queue/LaravelSqsHandler.php
+++ b/src/Queue/LaravelSqsHandler.php
@@ -7,8 +7,6 @@ use Bref\Context\Context;
 use Bref\Event\Sqs\SqsEvent;
 use Bref\Event\Sqs\SqsHandler;
 use Illuminate\Container\Container;
-use Illuminate\Contracts\Debug\ExceptionHandler;
-use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Queue\QueueManager;
 use Illuminate\Queue\SqsQueue;
 use Illuminate\Queue\WorkerOptions;
@@ -18,20 +16,12 @@ use Illuminate\Queue\WorkerOptions;
  */
 class LaravelSqsHandler extends SqsHandler
 {
-    /** @var Container */
-    private $container;
-    /** @var SqsClient */
-    private $sqs;
-    /** @var Dispatcher */
-    private $events;
-    /** @var ExceptionHandler */
-    private $exceptions;
-    /** @var string */
-    private $connectionName;
-    /** @var string */
-    private $queue;
+    private Container $container;
+    private SqsClient $sqs;
+    private string $connectionName;
+    private string $queue;
 
-    public function __construct(Container $container, Dispatcher $events, ExceptionHandler $exceptions, string $connection, string $queue)
+    public function __construct(Container $container, string $connection, string $queue)
     {
         $this->container = $container;
         $queueManager = $container->get('queue');
@@ -41,20 +31,19 @@ class LaravelSqsHandler extends SqsHandler
             throw new \RuntimeException("The '$connection' connection is not a SQS connection in the Laravel config");
         }
         $this->sqs = $queueConnector->getSqs();
-        $this->events = $events;
-        $this->exceptions = $exceptions;
         $this->connectionName = $connection;
         $this->queue = $queue;
     }
 
     public function handleSqs(SqsEvent $event, Context $context): void
     {
-        /** @var Worker $worker */
         $worker = $this->container->makeWith(Worker::class, [
             'isDownForMaintenance' => function () {
                 return false;
             },
         ]);
+
+        \assert($worker instanceof Worker);
 
         foreach ($event->getRecords() as $sqsRecord) {
             $message = $this->normalizeMessage($sqsRecord->toArray());

--- a/src/Queue/LaravelSqsHandler.php
+++ b/src/Queue/LaravelSqsHandler.php
@@ -16,10 +16,17 @@ use Illuminate\Queue\WorkerOptions;
  */
 class LaravelSqsHandler extends SqsHandler
 {
-    private Container $container;
-    private SqsClient $sqs;
-    private string $connectionName;
-    private string $queue;
+    /** @var Container $container */
+    private $container;
+
+    /** @var SqsClient */
+    private $sqs;
+
+    /** @var string */
+    private $connectionName;
+
+    /** @var string */
+    private $queue;
 
     public function __construct(Container $container, string $connection, string $queue)
     {
@@ -80,15 +87,20 @@ class LaravelSqsHandler extends SqsHandler
 
     protected function getWorkerOptions(): WorkerOptions
     {
-        return new WorkerOptions(
-            'default',
+        $options = [
             0,
-            512,
+            $memory = 512,
             0,
-            0,
+            $sleep = 0,
             0,
             false,
-            false
-        );
+            false,
+        ];
+
+        if (property_exists(WorkerOptions::class, 'name')) {
+            $options = array_merge(['default'], $options);
+        }
+
+        return new WorkerOptions(...$options);
     }
 }

--- a/src/Queue/LaravelSqsHandler.php
+++ b/src/Queue/LaravelSqsHandler.php
@@ -92,7 +92,7 @@ class LaravelSqsHandler extends SqsHandler
             $memory = 512,
             $timeout = 0,
             $sleep = 0,
-            $maxTries = 0,
+            $maxTries = 3,
             $force = false,
             $stopWhenEmpty = false,
             $maxJobs = 0,

--- a/src/Queue/LaravelSqsHandler.php
+++ b/src/Queue/LaravelSqsHandler.php
@@ -59,7 +59,7 @@ class LaravelSqsHandler extends SqsHandler
         foreach ($event->getRecords() as $sqsRecord) {
             $message = $this->normalizeMessage($sqsRecord->toArray());
 
-            $worker->runVaporJob(
+            $worker->runSqsJob(
                 $this->buildJob($message),
                 $this->connectionName,
                 $this->getWorkerOptions()

--- a/src/Queue/LaravelSqsHandler.php
+++ b/src/Queue/LaravelSqsHandler.php
@@ -88,13 +88,15 @@ class LaravelSqsHandler extends SqsHandler
     protected function getWorkerOptions(): WorkerOptions
     {
         $options = [
-            0,
+            $backoff = 0,
             $memory = 512,
-            0,
+            $timeout = 0,
             $sleep = 0,
-            0,
-            false,
-            false,
+            $maxTries = 0,
+            $force = false,
+            $stopWhenEmpty = false,
+            $maxJobs = 0,
+            $maxTime = 0,
         ];
 
         if (property_exists(WorkerOptions::class, 'name')) {

--- a/src/Queue/LaravelSqsHandler.php
+++ b/src/Queue/LaravelSqsHandler.php
@@ -12,7 +12,6 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Queue\Events\JobExceptionOccurred;
 use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Queue\Events\JobProcessing;
-use Illuminate\Queue\Jobs\SqsJob;
 use Illuminate\Queue\QueueManager;
 use Illuminate\Queue\SqsQueue;
 use Throwable;

--- a/src/Queue/SqsJob.php
+++ b/src/Queue/SqsJob.php
@@ -1,5 +1,4 @@
-<?php
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Bref\LaravelBridge\Queue;
 
@@ -8,10 +7,7 @@ use Illuminate\Queue\Jobs\SqsJob as LaravelSqsJob;
 class SqsJob extends LaravelSqsJob
 {
     /**
-     * Release the job back into the queue.
-     *
-     * @param int $delay
-     * @return void
+     * {@inheritDoc}
      */
     public function release($delay = 0)
     {
@@ -34,9 +30,7 @@ class SqsJob extends LaravelSqsJob
     }
 
     /**
-     * Get the number of times the job has been attempted.
-     *
-     * @return int
+     * {@inheritDoc}
      */
     public function attempts()
     {

--- a/src/Queue/SqsJob.php
+++ b/src/Queue/SqsJob.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Bref\LaravelBridge\Queue;
+
+use Illuminate\Queue\Jobs\SqsJob as LaravelSqsJob;
+
+class SqsJob extends LaravelSqsJob
+{
+    /**
+     * Release the job back into the queue.
+     *
+     * @param int $delay
+     * @return void
+     */
+    public function release($delay = 0)
+    {
+        $this->released = true;
+
+        $payload = $this->payload();
+
+        $payload['attempts'] = ($payload['attempts'] ?? 0) + 1;
+
+        $this->sqs->deleteMessage([
+            'QueueUrl' => $this->queue,
+            'ReceiptHandle' => $this->job['ReceiptHandle'],
+        ]);
+
+        $this->sqs->sendMessage([
+            'QueueUrl' => $this->queue,
+            'MessageBody' => json_encode($payload),
+            'DelaySeconds' => $this->secondsUntil($delay),
+        ]);
+    }
+
+    /**
+     * Get the number of times the job has been attempted.
+     *
+     * @return int
+     */
+    public function attempts()
+    {
+        return ($this->payload()['attempts'] ?? 0) + 1;
+    }
+}

--- a/src/Queue/SqsJob.php
+++ b/src/Queue/SqsJob.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Bref\LaravelBridge\Queue;
 

--- a/src/Queue/SqsJob.php
+++ b/src/Queue/SqsJob.php
@@ -4,6 +4,10 @@ namespace Bref\LaravelBridge\Queue;
 
 use Illuminate\Queue\Jobs\SqsJob as LaravelSqsJob;
 
+/**
+ * @author Taylor Otwell <taylor@laravel.com>
+ * @copyright Copyright (c) 2019, Taylor Otwell
+ */
 class SqsJob extends LaravelSqsJob
 {
     /**

--- a/src/Queue/Worker.php
+++ b/src/Queue/Worker.php
@@ -1,5 +1,4 @@
-<?php
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Bref\LaravelBridge\Queue;
 

--- a/src/Queue/Worker.php
+++ b/src/Queue/Worker.php
@@ -2,20 +2,13 @@
 
 namespace Bref\LaravelBridge\Queue;
 
+use Illuminate\Contracts\Queue\Job;
 use Illuminate\Queue\Worker as LaravelWorker;
 use Illuminate\Queue\WorkerOptions;
 
 class Worker extends LaravelWorker
 {
-    /**
-     * Process the given job.
-     *
-     * @param \Illuminate\Contracts\Queue\Job $job
-     * @param string $connectionName
-     * @param \Illuminate\Queue\WorkerOptions $options
-     * @return void
-     */
-    public function runVaporJob($job, $connectionName, WorkerOptions $options)
+    public function runSqsJob(Job $job, string $connectionName, WorkerOptions $options): void
     {
         pcntl_async_signals(true);
 

--- a/src/Queue/Worker.php
+++ b/src/Queue/Worker.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Bref\LaravelBridge\Queue;
 

--- a/src/Queue/Worker.php
+++ b/src/Queue/Worker.php
@@ -10,18 +10,6 @@ class Worker extends LaravelWorker
 {
     public function runSqsJob(Job $job, string $connectionName, WorkerOptions $options): void
     {
-        pcntl_async_signals(true);
-
-        // pcntl_signal(SIGALRM, function () use ($job) {
-        //     throw new VaporJobTimedOutException($job->resolveName());
-        // });
-
-        pcntl_alarm(
-            max($this->timeoutForJob($job, $options), 0)
-        );
-
         $this->runJob($job, $connectionName, $options);
-
-        pcntl_alarm(0);
     }
 }

--- a/src/Queue/Worker.php
+++ b/src/Queue/Worker.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Bref\LaravelBridge\Queue;
+
+use Illuminate\Queue\Worker as LaravelWorker;
+use Illuminate\Queue\WorkerOptions;
+
+class Worker extends LaravelWorker
+{
+    /**
+     * Process the given job.
+     *
+     * @param \Illuminate\Contracts\Queue\Job $job
+     * @param string $connectionName
+     * @param \Illuminate\Queue\WorkerOptions $options
+     * @return void
+     */
+    public function runVaporJob($job, $connectionName, WorkerOptions $options)
+    {
+        pcntl_async_signals(true);
+
+        // pcntl_signal(SIGALRM, function () use ($job) {
+        //     throw new VaporJobTimedOutException($job->resolveName());
+        // });
+
+        pcntl_alarm(
+            max($this->timeoutForJob($job, $options), 0)
+        );
+
+        $this->runJob($job, $connectionName, $options);
+
+        pcntl_alarm(0);
+    }
+}


### PR DESCRIPTION
Fixes #14
Fixes #22

### Change 1: Store job attempt in job payload
`ApproximateReceiveCount` should not be used when processing SQS jobs in Lambda, as it is very unreliable. See https://link.medium.com/uUkT2W9bTbb for more info.

This PR adds functionality to store the current attempt on the job payload, so we don't have to depend on `ApproximateReceiveCount`. This effectively means that the `attempt` value should be correctly set on every try. Because we can't update SQS messages, we always have to re-create a message, rather than releasing it back onto the queue.

This change will make `$this->job->attempts()` and descendants of it, (`$maxExceptions`, `$tries`), usable.

### Change 2: Refactor workers
This PR also changes the queue worker to use the frameworks built-in worker, in favour of the purpose built worker from this package. Now that we don't have to deal with the `ApproximateReceiveCount`, there is not need to use our own worker class, and we should rather use the default one provided by Laravel. This also means that jobs are now processed by the same system used by `queue:work` and Laravel Horizon, limiting the changes between platforms.

Note that Laravel's queue worker expects a maintenance mode status. As this feature is not implemented in this package, the value is hardcoded to `false`. This effectively means that the queue worker will simple ignore any maintenance mode set. This is in line with earlier versions of this package, that also ignored the maintenance mode.

---
The code is 'backwards compatible' in the sense that the example `worker.php` remains identical. If you did not change that, all should continue working as usual.

The code is heavily inspired (and sometimes copied) from https://github.com/laravel/vapor-core/. Attributions were giving where due. 