### PR TITLE
Make sure view.compiled is correctly defined + tests

### DIFF
--- a/src/BrefServiceProvider.php
+++ b/src/BrefServiceProvider.php
@@ -10,8 +10,19 @@ class BrefServiceProvider extends ServiceProvider
 {
     public function boot(): void
     {
+        $compiledViewDirectory = Config::get('view.compiled', '');
+
+        // Make sure the config is correctly declared. If not, Config::get will return an empty string
+        if (empty($compiledViewDirectory)) {
+            throw new RuntimeException('Configuration `view.compiled` is not declared');
+        }
+
+        // Make sure the declared view.compiled is a string
+        if (! is_string($compiledViewDirectory)) {
+            throw new RuntimeException('Configuration `view.compiled` must be a valid string');
+        }
+
         // Make sure the directory for compiled views exist
-        $compiledViewDirectory = Config::get('view.compiled');
         if (! is_dir($compiledViewDirectory)) {
             // The directory doesn't exist: let's create it, else Laravel will not create it automatically
             // and will fail with an error

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -7,7 +7,7 @@ use Symfony\Component\Process\Process;
 
 class FunctionalTest extends TestCase
 {
-    public function test()
+    public function test run without errors()
     {
         // We run the test via a separate process to ensure that we have a
         // blank Laravel kernel not impacted by
@@ -15,5 +15,15 @@ class FunctionalTest extends TestCase
         $handler->setWorkingDirectory(__DIR__);
         $handler->mustRun();
         $this->assertEquals("Before job\nProcessing podcast 12345\nAfter job\n", $handler->getOutput());
+        $this->assertEmpty($handler->getErrorOutput());
+    }
+
+    public function test make an error without view compiled path()
+    {
+        $handler = new Process(["php", "test-trigger.php"]);
+        $handler->setEnv(["VIEW_COMPILED_PATH" => null]);
+        $handler->setWorkingDirectory(__DIR__);
+        $handler->mustRun();
+        $this->assertNotEmpty($handler->getErrorOutput());
     }
 }


### PR DESCRIPTION
Hello 👋

A problem reported by a laravel-bridge user on bref's Slack. This fix is to make sure the `view.compiled` variable is correctly defined and, if not, it's returning an understandable error.

I try to add to test case, BUT, I did not successfully reproduce the error encounter by the user. Laravel is throwing an error before I reach bref's Service Provider.