### PR TITLE
fixed install conflict where package require older guzzlehttp/psr7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "bref/bref": "^1.0",
         "illuminate/queue": "^6.0|^7.0|^8.0",
         "illuminate/support": "^6.0|^7.0|^8.0",
-        "aws/aws-sdk-php": "^3.134"
+        "aws/aws-sdk-php": "^3.187"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",


### PR DESCRIPTION
This PR bump minimum aws sdk php version to `3.187` to resolve an issue where current version `3.134` require `guzzlehttp/psr7 ^1.4.1` but latest was sdk version `3.187` require `guzzlehttp/psr7 ^1.7.0`

<img width="1334" alt="image" src="https://user-images.githubusercontent.com/4704339/128308964-01703a85-1113-4a7a-bc7f-5197893f971e.png">

