### PR TITLE
Exclude .env and Lambda-reserved environment variables from final package

### DIFF
--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -1,4 +1,16 @@
 service: laravel
+useDotenv: true
+
+custom:
+    dotenv:
+        file: true
+        exclude:
+            - AWS_ACCESS_KEY_ID
+            - AWS_SECRET_ACCESS_KEY
+            - AWS_DEFAULT_REGION
+            - NODE_ENV
+        required:
+            - APP_KEY
 
 provider:
     name: aws
@@ -10,12 +22,14 @@ provider:
 
 package:
     # Directories to exclude from deployment
-    exclude:
-        - node_modules/**
-        - public/storage
-        - resources/assets/**
-        - storage/**
-        - tests/**
+    patterns:
+        - '!node_modules/**'
+        - '!public/storage'
+        - '!database/database.sqlite'
+        - '!resources/css/**'
+        - '!resources/js/**'
+        - '!storage/**'
+        - '!tests/**'
 
 functions:
     # This function runs the Laravel website/API
@@ -37,3 +51,4 @@ functions:
 plugins:
     # We need to include the Bref plugin
     - ./vendor/bref/bref
+    - serverless-dotenv-plugin


### PR DESCRIPTION
This PR just adds some improvements to the serverless.yml file to exclude .env files from the final deployed zip package.

Includes new plugin:
- https://www.serverless.com/plugins/serverless-dotenv-plugin

With this we add a small layer of security and also, we correct some deprecations in the excluded folders.

Deprecations fixes:
- https://www.serverless.com/framework/docs/deprecations/#NEW_PACKAGE_PATTERNS

More info about package patterns https://www.serverless.com/framework/docs/providers/aws/guide/packaging/#patterns