### PR TITLE
lambdaHashingVersion set to 20201221

### DIFF
--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -7,6 +7,7 @@ provider:
     # The stage of the application, e.g. dev, production, staging… ('dev' is the default)
     stage: dev
     runtime: provided.al2
+    lambdaHashingVersion: 20201221
 
 package:
     # Directories to exclude from deployment


### PR DESCRIPTION
The resolution of lambda version hashes was improved with a better algorithm, which will be used in the next major release.

More info: [https://www.serverless.com/framework/docs/deprecations/#LAMBDA_HASHING_VERSION_V2](https://www.serverless.com/framework/docs/deprecations/#LAMBDA_HASHING_VERSION_V2)

<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->
