### PR TITLE
fix: updated the layer version of php

### DIFF
--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -24,7 +24,7 @@ functions:
         handler: public/index.php
         timeout: 28 # in seconds (API Gateway has a timeout of 29 seconds)
         layers:
-            - ${bref:layer.php-80-fpm}
+            - ${bref:layer.php-81-fpm}
         events:
             - httpApi: '*'
     # This function lets us run artisan commands in Lambda
@@ -32,7 +32,7 @@ functions:
         handler: artisan
         timeout: 120 # in seconds
         layers:
-            - ${bref:layer.php-80} # PHP
+            - ${bref:layer.php-81} # PHP
             - ${bref:layer.console} # The "console" layer
 
 plugins:


### PR DESCRIPTION
Issue:
By default, we are configuration copied from this file path, when I run the `php artisan vendor:publish --tag=serverless-config` and deploy I am getting this below error
>{"message":"Internal Server Error"}

Reason :
As I checked the cloud watch log, I found below issue
> Fatal error: Composer detected issues in your platform: Your Composer dependencies require a PHP version ">= 8.1.0". You are running 8.0.24. in /var/task/vendor/composer/platform_check.php on line 24  


<br class="Apple-interchange-newline">

Fix:
Updated the layer to `php-81-fpm` from `php-80-fpm` to support current laravel version dependencies

Attachments:
![Screenshot 2022-10-28 at 12 56 22 PM](https://user-images.githubusercontent.com/37912771/198531195-6d8e4056-7bd6-4736-9558-9f95c3a9cabc.png)
![Screenshot 2022-10-28 at 12 56 40 PM](https://user-images.githubusercontent.com/37912771/198531201-7d573dc7-2b79-4ed7-8bd6-ea39f875a113.png)

