### PR TITLE
Removes lambda hashing version from template

### DIFF
--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -7,7 +7,6 @@ provider:
     # The stage of the application, e.g. dev, production, staging… ('dev' is the default)
     stage: dev
     runtime: provided.al2
-    lambdaHashingVersion: 20200924
 
 package:
     # Directories to exclude from deployment

--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -7,7 +7,7 @@ provider:
     # The stage of the application, e.g. dev, production, staging… ('dev' is the default)
     stage: dev
     runtime: provided.al2
-    lambdaHashingVersion: 20201221
+    lambdaHashingVersion: 20200924
 
 package:
     # Directories to exclude from deployment


### PR DESCRIPTION
Hi, everyone!

This PR removes the default lambda hash version of `serverless.yml` as it is no longer needed and the existing version is deprecated.

Closes #84 