### PR TITLE
Exclude .git directory from deployment

### DIFF
--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -16,6 +16,7 @@ package:
         - '!resources/assets/**'
         - '!storage/**'
         - '!tests/**'
+        - '!.git/**'
 
 functions:
     # This function runs the Laravel website/API


### PR DESCRIPTION
Due to some repository having a big .git files, this change adds the exclusion of the .git directory to the list of patterns in the deployment process. This also ensures that sensitive version control information is not deployed along with the rest of the code, reducing the size of the deployment package.

<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->
