### PR TITLE
Remove the need for setting the AWS account ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,6 @@ php artisan vendor:publish --tag=serverless-config
 
 This will create the `serverless.yml` config file.
 
-Next, we need to set up in the `AWS_ACCOUNT_ID` environment variable in your `serverless.yml`:
-
-```yml
-provider:
-  environment:
-    AWS_ACCOUNT_ID: ${aws:accountId}
-```
-
 Finally, deploy your app:
 
 ```bash

--- a/examples/getting-started/serverless.yml
+++ b/examples/getting-started/serverless.yml
@@ -23,7 +23,6 @@ provider:
     APP_URL: ${param:appUrl}
     APP_ENV: ${sls:stage}
     APP_DEBUG: ${param:debug}
-    AWS_ACCOUNT_ID: ${aws:accountId}
     ASSET_URL: https://${param:assetsBucket}/${sls:instanceId}
     LOG_LEVEL: ${param:logLevel}
     QUEUE_CONNECTION: ${param:queue, 'sqs'}

--- a/src/BrefServiceProvider.php
+++ b/src/BrefServiceProvider.php
@@ -53,13 +53,9 @@ class BrefServiceProvider extends ServiceProvider
         Config::set('filesystems.disks.s3.secret');
         Config::set('filesystems.disks.s3.token', env('AWS_SESSION_TOKEN'));
 
-        $account = env('AWS_ACCOUNT_ID');
-        $region = env('AWS_REGION', env('AWS_DEFAULT_REGION', 'us-east-1'));
-
         Config::set('queue.connections.sqs.key');
         Config::set('queue.connections.sqs.secret');
         Config::set('queue.connections.sqs.token', env('AWS_SESSION_TOKEN'));
-        Config::set('queue.connections.sqs.prefix', env('SQS_PREFIX', "https://sqs.{$region}.amazonaws.com/{$account}"));
 
         $this->app->when(QueueHandler::class)
             ->needs('$connection')


### PR DESCRIPTION
In the upcoming Laravel docs (https://github.com/brefphp/bref/pull/1424), we set us Laravel Queues using Lift, which lets us easily configure the SQS queue URL -> the SQS_PREFIX with account ID is useless there.

For those that don't use Lift, I also added some documentation that explains how to set `SQS_PREFIX` (as easy as copy/paste the example): https://github.com/brefphp/bref/pull/1424/commits/b69d852e719cae975e0c5d61f93061082a40dd4a

So I think we can now safely remove the constraint of having users set the AWS_ACCOUNT_ID in their config. That's one less step when getting started 🎉