### PR TITLE
Don't unset AWS key and secrets

### DIFF
--- a/src/BrefServiceProvider.php
+++ b/src/BrefServiceProvider.php
@@ -45,16 +45,8 @@ class BrefServiceProvider extends ServiceProvider
         Config::set('view.compiled', StorageDirectories::Path . '/framework/views');
         Config::set('cache.stores.file.path', StorageDirectories::Path . '/framework/cache');
 
-        Config::set('cache.stores.dynamodb.key');
-        Config::set('cache.stores.dynamodb.secret');
         Config::set('cache.stores.dynamodb.token', env('AWS_SESSION_TOKEN'));
-
-        Config::set('filesystems.disks.s3.key');
-        Config::set('filesystems.disks.s3.secret');
         Config::set('filesystems.disks.s3.token', env('AWS_SESSION_TOKEN'));
-
-        Config::set('queue.connections.sqs.key');
-        Config::set('queue.connections.sqs.secret');
         Config::set('queue.connections.sqs.token', env('AWS_SESSION_TOKEN'));
 
         $this->app->when(QueueHandler::class)


### PR DESCRIPTION
No longer needed to unset the key and secret for the session token to work.

Cache:

https://github.com/laravel/framework/blob/0b3fae2e8dd094433a760b09eb4366bb139fcf88/src/Illuminate/Cache/CacheManager.php#L268-L272

Filesystem

[..](https://github.com/laravel/framework/blob/0b3fae2e8dd094433a760b09eb4366bb139fcf88/src/Illuminate/Filesystem/FilesystemManager.php#L265-L267)

Queue

https://github.com/laravel/framework/blob/0b3fae2e8dd094433a760b09eb4366bb139fcf88/src/Illuminate/Queue/Connectors/SqsConnector.php#L21-L23