### PR TITLE
Fix the creation of `serverless.yml` to the correct directory

### DIFF
--- a/src/BrefServiceProvider.php
+++ b/src/BrefServiceProvider.php
@@ -65,7 +65,7 @@ class BrefServiceProvider extends ServiceProvider
 
         if ($this->app->runningInConsole()) {
             $this->publishes([
-                __DIR__ . '/../stubs/serverless.yml' => config_path('serverless.yml'),
+                __DIR__ . '/../stubs/serverless.yml' => base_path('serverless.yml'),
             ], 'serverless-config');
 
             $this->publishes([


### PR DESCRIPTION
Currently it is created in the `config/` subdirectory 🙃