### PR TITLE
Fix service provider running order

### DIFF
--- a/src/BrefServiceProvider.php
+++ b/src/BrefServiceProvider.php
@@ -34,7 +34,7 @@ class BrefServiceProvider extends ServiceProvider
             return;
         }
 
-        $this->app[Kernel::class]->pushMiddleware(Http\Middleware\ServeStaticAssets::class);
+        $this->app->useStoragePath(StorageDirectories::Path);
 
         $this->fixDefaultConfiguration();
 
@@ -61,7 +61,7 @@ class BrefServiceProvider extends ServiceProvider
      */
     public function boot(Dispatcher $dispatcher, LogManager $logManager, FailedJobProviderInterface $queueFailer)
     {
-        $this->app->useStoragePath(StorageDirectories::Path);
+        $this->app[Kernel::class]->pushMiddleware(Http\Middleware\ServeStaticAssets::class);
 
         if ($this->app->runningInConsole()) {
             $this->publishes([


### PR DESCRIPTION
This pull request introduces two changes in the timing of calls made in the service provider of the package.

## 1. Change storage path

Currently, the storage path is always changed. This means that it also happens in CI, and not only when deployed on bref. Furthermore, the change of the path can be moved to the `register` method, because it does not depend on any external services being registered.

## 2. Pushing ServeStaticAssets to the middleware stack

We can only be sure that the Kernel is registered in the service provider, in the `boot` method of our service provider. At the `register` stage, it could theoretically not been registered yet.

---

Tested and deployed to a test bref v2 app.

Fixes #101