### PR TITLE
Allow running Tinker commands on Lambda

### DIFF
--- a/src/StorageDirectories.php
+++ b/src/StorageDirectories.php
@@ -26,6 +26,7 @@ class StorageDirectories
             self::Path . '/bootstrap/cache',
             self::Path . '/framework/cache',
             self::Path . '/framework/views',
+            self::Path . '/psysh',
         ];
 
         $directories = array_filter($directories, static fn ($directory) => ! is_dir($directory));

--- a/src/bref-init.php
+++ b/src/bref-init.php
@@ -15,6 +15,11 @@ Bref::beforeStartup(static function () {
 
     MaintenanceMode::setUp();
 
+    // Move the location of the PsySH config cache to `/tmp` (because it is writable)
+    $xdgHome = StorageDirectories::Path . '/psysh';
+    $_SERVER['XDG_CONFIG_HOME'] = $_ENV['XDG_CONFIG_HOME'] = $xdgHome;
+    putenv("XDG_CONFIG_HOME=$xdgHome");
+
     $defaultConfigCachePath = $_SERVER['LAMBDA_TASK_ROOT'] . '/bootstrap/cache/config.php';
 
     if (file_exists($defaultConfigCachePath)) {


### PR DESCRIPTION
Fixes #77 

Example:

```bash
sls bref:cli --args="tinker --execute='phpinfo()'"
```

This isn't an interactive session, but we can use `--execute`, which is better than nothing.