### PR TITLE
Fix issue #112 - Request to AWS SES API failed. Reason: The Security Token included in the request is invalid 

### DIFF
--- a/src/BrefServiceProvider.php
+++ b/src/BrefServiceProvider.php
@@ -48,6 +48,7 @@ class BrefServiceProvider extends ServiceProvider
         Config::set('cache.stores.dynamodb.token', env('AWS_SESSION_TOKEN'));
         Config::set('filesystems.disks.s3.token', env('AWS_SESSION_TOKEN'));
         Config::set('queue.connections.sqs.token', env('AWS_SESSION_TOKEN'));
+        Config::set('services.ses.token', env('AWS_SESSION_TOKEN'));
 
         $this->app->when(QueueHandler::class)
             ->needs('$connection')


### PR DESCRIPTION
This PR will set services.ses.token value to `AWS_SESSION_TOKEN´ to fix issue #112 

Fixes #112 