### PR TITLE
Avoid fatal error when creating local directories

### DIFF
--- a/src/StorageDirectories.php
+++ b/src/StorageDirectories.php
@@ -31,7 +31,7 @@ class StorageDirectories
 
         $directories = array_filter($directories, static fn ($directory) => ! is_dir($directory));
 
-        if (count($directories)) {
+        if (count($directories) && defined('STDERR')) {
             fwrite(STDERR, 'Creating storage directories: ' . implode(', ', $directories) . PHP_EOL);
         }
 


### PR DESCRIPTION
As part of my migration to Bref v2, I stumbled on https://github.com/brefphp/laravel-bridge/issues/115. To solve the issue of the build server crashing with autoload, I changed my `bootstrap/app.php` file to invoke the `StorageDirectories::create()` function. This works on the build server and on Lambda, but crashes locally because the `Bref::beforeStartup` callback is never executed, so `STDERR` constant definition is never defined. Since this is just a helper output and not something critical, I thought we could get away by attempting to write to STDERR only if the constant has been defined so that it still works on local development without going through Bref startup while still making sure that the folders will be created