### PR TITLE
Set worker cache in QueueHandler

### DIFF
--- a/src/Queue/QueueHandler.php
+++ b/src/Queue/QueueHandler.php
@@ -50,7 +50,6 @@ class QueueHandler extends SqsHandler
      * @param  \Illuminate\Container\Container  $container
      * @param  \Illuminate\Contracts\Events\Dispatcher  $events
      * @param  \Illuminate\Contracts\Debug\ExceptionHandler  $exceptions
-     * @param  \Illuminate\Contracts\Cache\Repository  $cache
      * @param  string  $connection
      * @return void
      */
@@ -58,7 +57,6 @@ class QueueHandler extends SqsHandler
         protected Container $container,
         protected Dispatcher $events,
         protected ExceptionHandler $exceptions,
-        protected Cache $cache,
         protected string $connection,
     ) {
         $queue = $container->make(QueueManager::class)
@@ -86,7 +84,10 @@ class QueueHandler extends SqsHandler
             'isDownForMaintenance' => fn () => MaintenanceMode::active(),
         ]);
 
-        $worker->setCache($this->cache);
+        /** @var Cache $cache */
+        $cache = $this->container->make(Cache::class);
+
+        $worker->setCache($cache);
 
         foreach ($event->getRecords() as $sqsRecord) {
             $timeout = $this->calculateJobTimeout($context->getRemainingTimeInMillis());

--- a/src/Queue/QueueHandler.php
+++ b/src/Queue/QueueHandler.php
@@ -84,10 +84,9 @@ class QueueHandler extends SqsHandler
             'isDownForMaintenance' => fn () => MaintenanceMode::active(),
         ]);
 
-        /** @var Cache $cache */
-        $cache = $this->container->make(Cache::class);
-
-        $worker->setCache($cache);
+        $worker->setCache(
+            $this->container->make(Cache::class)
+        );
 
         foreach ($event->getRecords() as $sqsRecord) {
             $timeout = $this->calculateJobTimeout($context->getRemainingTimeInMillis());

--- a/src/Queue/QueueHandler.php
+++ b/src/Queue/QueueHandler.php
@@ -11,13 +11,13 @@ use Bref\Event\Sqs\SqsEvent;
 use Bref\Event\Sqs\SqsHandler;
 use Bref\Event\Sqs\SqsRecord;
 
-use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Queue\SqsQueue;
 use Illuminate\Queue\QueueManager;
 use Illuminate\Queue\WorkerOptions;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Contracts\Cache\Repository as Cache;
 
 use Bref\LaravelBridge\MaintenanceMode;
 


### PR DESCRIPTION
Sets the worker cache in the QueueHandler, similar to how it is done in the [Laravel WorkCommand](https://github.com/illuminate/queue/blob/800042047075cb44068cd12f3b9e9a4ef6ea12d2/Console/WorkCommand.php#L136). This is required to support jobs with `maxExceptions`.

Fixes issue #121.