### PR TITLE
Option to not update configs with AWS tokens

### DIFF
--- a/config/bref.php
+++ b/config/bref.php
@@ -30,4 +30,17 @@ return [
 
     'request_context' => false,
 
+    /*
+    |--------------------------------------------------------------------------
+    | Fix AWS role credentials
+    |--------------------------------------------------------------------------
+    |
+    | Laravel does not use AWS_SESSION_TOKEN environment vars by default
+    | Bref can automatically add these tokens into your configuration
+    | If you are not using AWS Roles you may need to disable this.
+    |
+    */
+
+    'aws_session_tokens' => true,
+
 ];

--- a/config/bref.php
+++ b/config/bref.php
@@ -35,12 +35,13 @@ return [
     | Use AWS credential tokens
     |--------------------------------------------------------------------------
     |
-    | Laravel does not use AWS_SESSION_TOKEN environment vars by default
-    | Bref can automatically add these tokens into your configuration
-    | If you are not using AWS Roles you may need to disable this.
+    | Bref fixes Laravel to use the AWS_SESSION_TOKEN environment variable
+    | provided by AWS Lambda automatically (required for AWS credentials to work).
+    | You should disable that only if you set your own AWS access keys manually
+    | (which is not recommended in most cases).
     |
     */
 
-    'use_session_tokens' => true,
+    'use_session_token' => true,
 
 ];

--- a/config/bref.php
+++ b/config/bref.php
@@ -32,7 +32,7 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Fix AWS role credentials
+    | Use AWS credential tokens
     |--------------------------------------------------------------------------
     |
     | Laravel does not use AWS_SESSION_TOKEN environment vars by default
@@ -41,6 +41,6 @@ return [
     |
     */
 
-    'aws_session_tokens' => true,
+    'use_session_tokens' => true,
 
 ];

--- a/src/BrefServiceProvider.php
+++ b/src/BrefServiceProvider.php
@@ -142,5 +142,4 @@ class BrefServiceProvider extends ServiceProvider
             Config::set('logging.default', 'stderr');
         }
     }
-
 }

--- a/src/BrefServiceProvider.php
+++ b/src/BrefServiceProvider.php
@@ -45,7 +45,7 @@ class BrefServiceProvider extends ServiceProvider
         Config::set('view.compiled', StorageDirectories::Path . '/framework/views');
         Config::set('cache.stores.file.path', StorageDirectories::Path . '/framework/cache');
 
-        if (Config::get('bref.use_session_tokens', true)) {
+        if (Config::get('bref.use_session_token', true)) {
             Config::set('cache.stores.dynamodb.token', env('AWS_SESSION_TOKEN'));
             Config::set('filesystems.disks.s3.token', env('AWS_SESSION_TOKEN'));
             Config::set('queue.connections.sqs.token', env('AWS_SESSION_TOKEN'));

--- a/src/BrefServiceProvider.php
+++ b/src/BrefServiceProvider.php
@@ -39,14 +39,17 @@ class BrefServiceProvider extends ServiceProvider
         $this->fixDefaultConfiguration();
 
         Config::set('app.mix_url', Config::get('app.asset_url'));
-        
+
         Config::set('trustedproxy.proxies', ['0.0.0.0/0', '2000:0:0:0:0:0:0:0/3']);
-        
+
         Config::set('view.compiled', StorageDirectories::Path . '/framework/views');
         Config::set('cache.stores.file.path', StorageDirectories::Path . '/framework/cache');
-        
-        if (Config::get('bref.aws_session_tokens', true)) {
-            $this->fixAWSCredentials();
+
+        if (Config::get('bref.use_session_tokens', true)) {
+            Config::set('cache.stores.dynamodb.token', env('AWS_SESSION_TOKEN'));
+            Config::set('filesystems.disks.s3.token', env('AWS_SESSION_TOKEN'));
+            Config::set('queue.connections.sqs.token', env('AWS_SESSION_TOKEN'));
+            Config::set('services.ses.token', env('AWS_SESSION_TOKEN'));
         }
 
         $this->app->when(QueueHandler::class)
@@ -140,16 +143,4 @@ class BrefServiceProvider extends ServiceProvider
         }
     }
 
-    /**
-     * Import AWS Session token from environment variables to configuration.
-     *
-     * @return void
-     */
-    protected function fixAWSCredentials(): void
-    {
-        Config::set('cache.stores.dynamodb.token', env('AWS_SESSION_TOKEN'));
-        Config::set('filesystems.disks.s3.token', env('AWS_SESSION_TOKEN'));
-        Config::set('queue.connections.sqs.token', env('AWS_SESSION_TOKEN'));
-        Config::set('services.ses.token', env('AWS_SESSION_TOKEN'));
-    }
 }


### PR DESCRIPTION
Although it's recommended to use AWS roles that's not always possible.

If the application is setting AWS keys and secrets with credentials which do not need an AWS token, adding the token in from the function role will cause the credentials to become invalid.

This PR adds a config option which disables updating the AWS configs with AWS_SESSION_TOKEN