### PR TITLE
Take an optional $path parameter when bootstrapping Octane

### DIFF
--- a/src/Http/OctaneHandler.php
+++ b/src/Http/OctaneHandler.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 class OctaneHandler extends HttpHandler
 {
-    private OctaneClient $octaneClient;
+    protected OctaneClient $octaneClient;
 
     public function __construct()
     {

--- a/src/Http/OctaneHandler.php
+++ b/src/Http/OctaneHandler.php
@@ -16,12 +16,12 @@ use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 class OctaneHandler extends HttpHandler
 {
-    protected OctaneClient $octaneClient;
+    private OctaneClient $octaneClient;
 
-    public function __construct()
+    public function __construct(?string $path = null)
     {
         $this->octaneClient = new OctaneClient(
-            getcwd(),
+            $path ?? getcwd(),
             (bool) ($_ENV['OCTANE_PERSIST_DATABASE_SESSIONS'] ?? false)
         );
     }


### PR DESCRIPTION
The hardcoded option `getcwd()` will always resolve to `/var/task/` and will require that the Laravel installation must be done at the root of the project. Variables like `BREF_AUTOLOAD_PATH` always allowed us to deviate from the default since we could point Bref to the proper position of the autoloader.

This PR opens up an optional parameter at the constructor of the `OctaneHandler` so that we can write our own file-based Bref Handler as follows:

```
<?php declare(strict_types=1);

use Bref\LaravelBridge\Http\OctaneHandler;

return new OctaneHandler(__DIR__ .'/../../../my/path/to/laravel/root/folder');
```

Having this as the Entrypoint of Lambda allows us to reuse all of the code present in this package while still being able to customize Laravel.