### PR TITLE
Added environment variable not to run config:cache

### DIFF
--- a/src/bref-init.php
+++ b/src/bref-init.php
@@ -15,6 +15,12 @@ Bref::beforeStartup(static function () {
 
     MaintenanceMode::setUp();
 
+    $shouldCache = env('BREF_LARAVEL_CACHE_CONFIG', env('APP_ENV') !== 'local');
+
+    if (! $shouldCache) {
+        return;
+    }
+
     // Move the location of the PsySH config cache to `/tmp` (because it is writable)
     $xdgHome = StorageDirectories::Path . '/psysh';
     $_SERVER['XDG_CONFIG_HOME'] = $_ENV['XDG_CONFIG_HOME'] = $xdgHome;

--- a/src/bref-init.php
+++ b/src/bref-init.php
@@ -15,16 +15,16 @@ Bref::beforeStartup(static function () {
 
     MaintenanceMode::setUp();
 
+    // Move the location of the PsySH config cache to `/tmp` (because it is writable)
+    $xdgHome = StorageDirectories::Path . '/psysh';
+    $_SERVER['XDG_CONFIG_HOME'] = $_ENV['XDG_CONFIG_HOME'] = $xdgHome;
+    putenv("XDG_CONFIG_HOME=$xdgHome");
+
     $shouldCache = env('BREF_LARAVEL_CACHE_CONFIG', env('APP_ENV') !== 'local');
 
     if (! $shouldCache) {
         return;
     }
-
-    // Move the location of the PsySH config cache to `/tmp` (because it is writable)
-    $xdgHome = StorageDirectories::Path . '/psysh';
-    $_SERVER['XDG_CONFIG_HOME'] = $_ENV['XDG_CONFIG_HOME'] = $xdgHome;
-    putenv("XDG_CONFIG_HOME=$xdgHome");
 
     $defaultConfigCachePath = $_SERVER['LAMBDA_TASK_ROOT'] . '/bootstrap/cache/config.php';
 


### PR DESCRIPTION
Addition of environment variable `BREF_LARAVEL_CACHE_CONFIG` that does not run config:cache.

Fixed #105

I didn't know how to write the test, so I checked it manually.

# Local development (Docker Compose)

```yaml
services:
  app:
    environment:
      BREF_LARAVEL_CACHE_CONFIG: 0 # true, false, 0, 1
```

# Lambda

```yaml
functions:
  app:
    environment:
      BREF_LARAVEL_CACHE_CONFIG: 0 # true, false, 0, 1
```