### PR TITLE
fix: resolve Laravel home using __DIR__

### DIFF
--- a/src/bref-init.php
+++ b/src/bref-init.php
@@ -8,7 +8,7 @@ use Bref\LaravelBridge\StorageDirectories;
 
 Bref::beforeStartup(static function () {
     $laravelHome = __DIR__ . '/../../../../';
-    
+
     if (! defined('STDERR')) {
         define('STDERR', fopen('php://stderr', 'wb'));
     }

--- a/src/bref-init.php
+++ b/src/bref-init.php
@@ -7,7 +7,7 @@ use Bref\LaravelBridge\MaintenanceMode;
 use Bref\LaravelBridge\StorageDirectories;
 
 Bref::beforeStartup(static function () {
-    $laravelHome = $_ENV['LAMBA_ROOT_TASK'] ?? __DIR__ . '/../../../../';
+    $laravelHome = $_ENV['LARAVEL_HOME'] ?? __DIR__ . '/../../../../';
 
     if (! defined('STDERR')) {
         define('STDERR', fopen('php://stderr', 'wb'));

--- a/src/bref-init.php
+++ b/src/bref-init.php
@@ -7,6 +7,8 @@ use Bref\LaravelBridge\MaintenanceMode;
 use Bref\LaravelBridge\StorageDirectories;
 
 Bref::beforeStartup(static function () {
+    $laravelHome = __DIR__ . '/../../../../';
+    
     if (! defined('STDERR')) {
         define('STDERR', fopen('php://stderr', 'wb'));
     }
@@ -26,7 +28,7 @@ Bref::beforeStartup(static function () {
         return;
     }
 
-    $defaultConfigCachePath = $_SERVER['LAMBDA_TASK_ROOT'] . '/bootstrap/cache/config.php';
+    $defaultConfigCachePath = $laravelHome . '/bootstrap/cache/config.php';
 
     if (file_exists($defaultConfigCachePath)) {
         return;
@@ -43,7 +45,7 @@ Bref::beforeStartup(static function () {
         fwrite(STDERR, "Running 'php artisan config:cache' to cache the Laravel configuration\n");
 
         // 1>&2 redirects the output to STDERR to avoid messing up HTTP responses with FPM
-        passthru('php artisan config:cache 1>&2');
+        passthru("php {$laravelHome}artisan config:cache 1>&2");
     }
 });
 

--- a/src/bref-init.php
+++ b/src/bref-init.php
@@ -7,7 +7,7 @@ use Bref\LaravelBridge\MaintenanceMode;
 use Bref\LaravelBridge\StorageDirectories;
 
 Bref::beforeStartup(static function () {
-    $laravelHome = __DIR__ . '/../../../../';
+    $laravelHome = $_ENV['LARAVEL_HOME'] ?? __DIR__ . '/../../../../';
 
     if (! defined('STDERR')) {
         define('STDERR', fopen('php://stderr', 'wb'));

--- a/src/bref-init.php
+++ b/src/bref-init.php
@@ -7,7 +7,7 @@ use Bref\LaravelBridge\MaintenanceMode;
 use Bref\LaravelBridge\StorageDirectories;
 
 Bref::beforeStartup(static function () {
-    $laravelHome = $_ENV['LARAVEL_HOME'] ?? __DIR__ . '/../../../../';
+    $laravelHome = $_ENV['LAMBA_ROOT_TASK'] ?? __DIR__ . '/../../../../';
 
     if (! defined('STDERR')) {
         define('STDERR', fopen('php://stderr', 'wb'));


### PR DESCRIPTION
<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->

When using a mono repository, the Laravel folder is not the root folder. Hence, we cannot simply take the Lambda Root and expect Laravel files to be present. Instead, this PR uses the current directory of the script and just finds the Laravel files relatively via going up the directory tree.
