### PR TITLE
Bump laravel Octane version for Laravel 10 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "illuminate/http": "^8.0 || ^9.0 || ^10.0",
         "illuminate/queue": "^8.0 || ^9.0 || ^10.0",
         "illuminate/support": "^8.0 || ^9.0 || ^10.0",
-        "laravel/octane": "^1.2",
+        "laravel/octane": "^2.1",
         "riverline/multipart-parser": "^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
Currrently the package is marked as compatible with octane 1.2 explicitly, which makes any Laravel 10.x (which is only compatible with octane 2.x) instalation fall back to bref/laravel-bridge:^1.2 , since that is the last version that does not include the octane requirement in its dependencies.

This pull request bumps the required octane version to "^2.1" making it compatible with Laravel 10.x

Resolves issue #132 