### PR TITLE
Set correct queue name from sqs job event

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^8.0",
         "aws/aws-sdk-php": "^3.222",
-        "bref/bref": "^2.0",
+        "bref/bref": "^2.1.8",
         "illuminate/container": "^8.0 || ^9.0 || ^10.0",
         "illuminate/contracts": "^8.0 || ^9.0 || ^10.0",
         "illuminate/http": "^8.0 || ^9.0 || ^10.0",

--- a/src/Queue/QueueHandler.php
+++ b/src/Queue/QueueHandler.php
@@ -124,7 +124,7 @@ class QueueHandler extends SqsHandler
             $this->sqs,
             $message,
             $this->connection,
-            $this->queueName,
+            $sqsRecord->getQueueName() ?? $this->queueName,
         );
     }
 

--- a/src/Queue/QueueHandler.php
+++ b/src/Queue/QueueHandler.php
@@ -38,13 +38,6 @@ class QueueHandler extends SqsHandler
     protected const JOB_TIMEOUT_SAFETY_MARGIN = 1.0;
 
     /**
-     * The name of the SQS queue.
-     *
-     * @var string
-     */
-    protected string $queueName;
-
-    /**
      * Creates a new SQS queue handler instance.
      *
      * @param  \Illuminate\Container\Container  $container
@@ -66,7 +59,6 @@ class QueueHandler extends SqsHandler
             throw new RuntimeException('Default queue connection is not a SQS connection');
         }
 
-        $this->queueName = $queue->getQueue(null);
         $this->sqs = $queue->getSqs();
     }
 
@@ -124,7 +116,7 @@ class QueueHandler extends SqsHandler
             $this->sqs,
             $message,
             $this->connection,
-            $sqsRecord->getQueueName() ?? $this->queueName,
+            $sqsRecord->getQueueName(),
         );
     }
 


### PR DESCRIPTION
## Why is this needed?
When using laravel queue name suffix feature (`queue.connections.sqs.suffix`), laravel will allow to dispatch a job using `onQueue` simply with the queue base name.

This will:
- always set the correct queue name where the job originated from.
- allow to work with multiple queues.

## Dependencies
- Bump `bref/bref` to `v2.1.8` to support this changes.

## Needs
- brefphp/bref/pull/1690