### PR TITLE
Setting whether to output the initialization log

### DIFF
--- a/config/bref.php
+++ b/config/bref.php
@@ -30,4 +30,15 @@ return [
 
     'request_context' => false,
 
+    /*
+    |--------------------------------------------------------------------------
+    | Log output at initialization
+    |--------------------------------------------------------------------------
+    |
+    | Here you can choose whether to log the Laravel application initialization
+    | process performed by Bref. These logs are output before the Laravel
+    | application starts, so they are not formatted by `logging.default`.
+    |
+    */
+    'log_init' => true,
 ];

--- a/config/bref.php
+++ b/config/bref.php
@@ -40,5 +40,5 @@ return [
     | application starts, so they are not formatted by `logging.default`.
     |
     */
-    'log_init' => true,
+    'log_init' => env('BREF_LARAVEL_BRIDGE_LOG_INIT', true),
 ];

--- a/config/bref.php
+++ b/config/bref.php
@@ -30,15 +30,4 @@ return [
 
     'request_context' => false,
 
-    /*
-    |--------------------------------------------------------------------------
-    | Log output at initialization
-    |--------------------------------------------------------------------------
-    |
-    | Here you can choose whether to log the Laravel application initialization
-    | process performed by Bref. These logs are output before the Laravel
-    | application starts, so they are not formatted by `logging.default`.
-    |
-    */
-    'log_init' => env('BREF_LARAVEL_BRIDGE_LOG_INIT', true),
 ];

--- a/src/StorageDirectories.php
+++ b/src/StorageDirectories.php
@@ -31,7 +31,7 @@ class StorageDirectories
 
         $directories = array_filter($directories, static fn ($directory) => ! is_dir($directory));
 
-        if (count($directories) && defined('STDERR') && getenv('BREF_LARAVEL_LOG_INIT')) {
+        if (count($directories) && defined('STDERR') && !getenv('BREF_LARAVEL_OMIT_INITLOG')) {
             fwrite(STDERR, 'Creating storage directories: ' . implode(', ', $directories) . PHP_EOL);
         }
 

--- a/src/StorageDirectories.php
+++ b/src/StorageDirectories.php
@@ -31,7 +31,7 @@ class StorageDirectories
 
         $directories = array_filter($directories, static fn ($directory) => ! is_dir($directory));
 
-        if (count($directories) && defined('STDERR') && getenv('BREF_LARAVEL_BRIDGE_LOG_INIT')) {
+        if (count($directories) && defined('STDERR') && getenv('BREF_LARAVEL_LOG_INIT')) {
             fwrite(STDERR, 'Creating storage directories: ' . implode(', ', $directories) . PHP_EOL);
         }
 

--- a/src/StorageDirectories.php
+++ b/src/StorageDirectories.php
@@ -18,7 +18,7 @@ class StorageDirectories
      *
      * @return void
      */
-    public static function create(bool $shouldLog)
+    public static function create()
     {
         $directories = [
             // self::Path . '/app',
@@ -31,7 +31,7 @@ class StorageDirectories
 
         $directories = array_filter($directories, static fn ($directory) => ! is_dir($directory));
 
-        if (count($directories) && defined('STDERR') && $shouldLog) {
+        if (count($directories) && defined('STDERR') && getenv('BREF_LARAVEL_BRIDGE_LOG_INIT')) {
             fwrite(STDERR, 'Creating storage directories: ' . implode(', ', $directories) . PHP_EOL);
         }
 

--- a/src/StorageDirectories.php
+++ b/src/StorageDirectories.php
@@ -18,7 +18,7 @@ class StorageDirectories
      *
      * @return void
      */
-    public static function create()
+    public static function create(bool $shouldLog)
     {
         $directories = [
             // self::Path . '/app',
@@ -31,7 +31,7 @@ class StorageDirectories
 
         $directories = array_filter($directories, static fn ($directory) => ! is_dir($directory));
 
-        if (count($directories) && defined('STDERR')) {
+        if (count($directories) && defined('STDERR') && $shouldLog) {
             fwrite(STDERR, 'Creating storage directories: ' . implode(', ', $directories) . PHP_EOL);
         }
 

--- a/src/bref-init.php
+++ b/src/bref-init.php
@@ -16,7 +16,7 @@ Bref::beforeStartup(static function () {
         getenv('BREF_LARAVEL_BRIDGE_LOG_INIT') === false ? true
         : (bool) getenv('BREF_LARAVEL_BRIDGE_LOG_INIT');
 
-    StorageDirectories::create($shouldLogInit);
+    StorageDirectories::create();
 
     MaintenanceMode::setUp();
 

--- a/src/bref-init.php
+++ b/src/bref-init.php
@@ -41,7 +41,7 @@ Bref::beforeStartup(static function () {
         putenv("APP_CONFIG_CACHE={$newConfigCachePath}");
 
         $outputDestination = '> /dev/null';
-        if (getenv('BREF_LARAVEL_BRIDGE_LOG_INIT')) {
+        if (getenv('BREF_LARAVEL_LOG_INIT')) {
             fwrite(STDERR, "Running 'php artisan config:cache' to cache the Laravel configuration\n");
             // 1>&2 redirects the output to STDERR to avoid messing up HTTP responses with FPM
             $outputDestination = '1>&2';

--- a/src/bref-init.php
+++ b/src/bref-init.php
@@ -41,7 +41,7 @@ Bref::beforeStartup(static function () {
         putenv("APP_CONFIG_CACHE={$newConfigCachePath}");
 
         $outputDestination = '> /dev/null';
-        if (getenv('BREF_LARAVEL_LOG_INIT')) {
+        if (!getenv('BREF_LARAVEL_OMIT_INITLOG')) {
             fwrite(STDERR, "Running 'php artisan config:cache' to cache the Laravel configuration\n");
             // 1>&2 redirects the output to STDERR to avoid messing up HTTP responses with FPM
             $outputDestination = '1>&2';

--- a/src/bref-init.php
+++ b/src/bref-init.php
@@ -11,12 +11,10 @@ Bref::beforeStartup(static function () {
         define('STDERR', fopen('php://stderr', 'wb'));
     }
 
-    $config = include(__DIR__ . '/../config/bref.php');
-    $extraConfigPath = $_SERVER['LAMBDA_TASK_ROOT'] . '/config/bref.php';
-    if (file_exists($extraConfigPath)) {
-        $config = array_merge($config, include($extraConfigPath));
-    }
-    $shouldLogInit = (bool)($config['log_init'] ?? true);
+    // Save init log by default if environment variable is not set
+    $shouldLogInit =
+        getenv('BREF_LARAVEL_BRIDGE_LOG_INIT') === false ? true
+        : (bool) getenv('BREF_LARAVEL_BRIDGE_LOG_INIT');
 
     StorageDirectories::create($shouldLogInit);
 


### PR DESCRIPTION
Hi!

In this pull request, I propose a configurable option to selectively enable logging for the Laravel application initialization process orchestrated by Bref.

Added `log_init` option to the config file published with `php artisan vendor:publish --tag=bref-config`.

### Motivation

The intention is to streamline the log output to CloudWatch by allowing selective logging, enhancing the readability and utility of the logs.

Currently, logs such as the following are output.

```
Creating storage directories: /tmp/storage/bootstrap/cache, /tmp/storage/framework/cache, /tmp/storage/framework/views, /tmp/storage/psysh
Running 'php artisan config:cache' to cache the Laravel configuration
INFO  Configuration cached successfully.  
```

These logs are useful for understanding how Bref is working within the Lambda runtime and whether the configuration of the Laravel application we have deployed is as intended.

However, this verbosity becomes superfluous when multiple cold starts occur in rapid succession, as the same messages are replicated each time.
*(For example, when `Bref\LaravelBridge\Queue\QueueHandler` handles a large number of "Push Notifications" sent simultaneously)*

This option aims to provide flexibility in managing log verbosity based on the developers' needs during different stages of deployment and operation.

Thank you.