### PR TITLE
Use `error` level for queue failure

### DIFF
--- a/src/BrefServiceProvider.php
+++ b/src/BrefServiceProvider.php
@@ -89,7 +89,7 @@ class BrefServiceProvider extends ServiceProvider
         );
 
         $dispatcher->listen(
-            fn (JobExceptionOccurred $event) => $logManager->info(
+            fn (JobExceptionOccurred $event) => $logManager->error(
                 "Job failed {$event->job->getJobId()}",
                 ['name' => $event->job->resolveName()]
             )


### PR DESCRIPTION
Related to #147.

This would allow someone to change their `logging.channels.*.level` to `notice` and not see the `Processed job` messages.