### PR TITLE
fixes logging of scheduled tasks

### DIFF
--- a/src/BrefServiceProvider.php
+++ b/src/BrefServiceProvider.php
@@ -4,6 +4,8 @@ namespace Bref\LaravelBridge;
 
 use Bref\LaravelBridge\Queue\QueueHandler;
 
+use Illuminate\Console\Events\ScheduledTaskStarting;
+
 use Illuminate\Log\LogManager;
 
 use Illuminate\Support\Facades\Config;
@@ -103,6 +105,13 @@ class BrefServiceProvider extends ServiceProvider
                 $event->exception
             )
         );
+
+        if (file_exists('/proc/1/fd/1')) {
+            $dispatcher->listen(
+                ScheduledTaskStarting::class,
+                fn(ScheduledTaskStarting $task) => $task->task->appendOutputTo('/proc/1/fd/1'),
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
Due to the way that Laravel [executes scheduled tasks](https://github.com/laravel/framework/blob/8ca1b5bbb9811585b58154a9e69aa0c67583e097/src/Illuminate/Console/Scheduling/CommandBuilder.php#L31-L38), coupled with bref sending everything to stderr ([by default](https://github.com/brefphp/laravel-bridge/blob/1dd21c63c3b14a12b4a73bb79fbc2854d2556349/src/BrefServiceProvider.php#L139-L141)) logging inside of scheduled tasks end up in /dev/null.

In CloudWatch you will see commands run like so:

```

2024-07-26 18:44:10 Running ['artisan' example:command] ... 194ms DONE
--
⇂ '/opt/bin/php' 'artisan' example:command > '/dev/null' 2>&1
```

With this change you can now see logs:

```
2024-07-27 00:02:09 Running ['artisan' example:command] [2024-07-27 00:02:09] staging.DEBUG: first debug
--
[2024-07-27 00:02:09] staging.DEBUG: second debug
... 132ms DONE
⇂ '/opt/bin/php' 'artisan' example:command >> '/proc/1/fd/1' 2>&1
```

I didn't do any real in depth look into the availability of `/proc/1/fd/1` but it would fail on my mac so I added the `file_exists()` check.

Can add tests if desired, hooking into this even seemed like the least intrusive way to accomplish this.