### PR TITLE
Prevent crash if key attribute is missing

### DIFF
--- a/src/BrefServiceProvider.php
+++ b/src/BrefServiceProvider.php
@@ -162,7 +162,7 @@ class BrefServiceProvider extends ServiceProvider
                 continue;
             }
             // If a different key is in the config than in the environment variables
-            if ($connection['key'] && $connection['key'] !== $accessKeyId) {
+            if (isset($connection['key']) && $connection['key'] !== $accessKeyId) {
                 continue;
             }
 
@@ -175,7 +175,7 @@ class BrefServiceProvider extends ServiceProvider
                 continue;
             }
             // If a different key is in the config than in the environment variables
-            if ($disk['key'] && $disk['key'] !== $accessKeyId) {
+            if (isset($disk['key']) && $disk['key'] !== $accessKeyId) {
                 continue;
             }
 
@@ -188,7 +188,7 @@ class BrefServiceProvider extends ServiceProvider
                 continue;
             }
             // If a different key is in the config than in the environment variables
-            if ($store['key'] && $store['key'] !== $accessKeyId) {
+            if (isset($store['key']) && $store['key'] !== $accessKeyId) {
                 continue;
             }
 


### PR DESCRIPTION
<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->

Hi, I've a set of Lambda that use Bref and Laravel 11.
After updating to 2.4.0 Lambdas started to crash with the following stack trace:

```
development.ERROR: Undefined array key "key" {"exception":"[object] (ErrorException(code: 0): Undefined array key \"key\" at /var/task/vendor/bref/laravel-bridge/src/BrefServiceProvider.php:165)
[stacktrace]
#0 /var/task/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php(256): Illuminate\\Foundation\\Bootstrap\\HandleExceptions->handleError(2, 'Undefined array...', '/var/task/vendo...', 165)
#1 /var/task/vendor/bref/laravel-bridge/src/BrefServiceProvider.php(165): Illuminate\\Foundation\\Bootstrap\\HandleExceptions->Illuminate\\Foundation\\Bootstrap\\{closure}(2, 'Undefined array...', '/var/task/vendo...', 165)
#2 /var/task/vendor/bref/laravel-bridge/src/BrefServiceProvider.php(50): Bref\\LaravelBridge\\BrefServiceProvider->fixAwsCredentialsConfig()
#3 /var/task/vendor/laravel/framework/src/Illuminate/Foundation/Application.php(868): Bref\\LaravelBridge\\BrefServiceProvider->register()
#4 /var/task/vendor/laravel/framework/src/Illuminate/Foundation/ProviderRepository.php(75): Illuminate\\Foundation\\Application->register(Object(Bref\\LaravelBridge\\BrefServiceProvider))
#5 /var/task/vendor/laravel/framework/src/Illuminate/Foundation/Application.php(843): Illuminate\\Foundation\\ProviderRepository->load(Array)
#6 /var/task/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/RegisterProviders.php(37): Illuminate\\Foundation\\Application->registerConfiguredProviders()
#7 /var/task/vendor/laravel/framework/src/Illuminate/Foundation/Application.php(316): Illuminate\\Foundation\\Bootstrap\\RegisterProviders->bootstrap(Object(Illuminate\\Foundation\\Application))
#8 /var/task/vendor/laravel/framework/src/Illuminate/Foundation/Console/Kernel.php(473): Illuminate\\Foundation\\Application->bootstrapWith(Array)
#9 /var/task/vendor/laravel/framework/src/Illuminate/Foundation/Console/Kernel.php(195): Illuminate\\Foundation\\Console\\Kernel->bootstrap()
#10 /var/task/vendor/laravel/framework/src/Illuminate/Foundation/Application.php(1203): Illuminate\\Foundation\\Console\\Kernel->handle(Object(Symfony\\Component\\Console\\Input\\ArgvInput), Object(Symfony\\Component\\Console\\Output\\ConsoleOutput))
#11 /var/task/artisan(13): Illuminate\\Foundation\\Application->handleCommand(Object(Symfony\\Component\\Console\\Input\\ArgvInput))
#12 {main}
```

I've added an additional guard against key attribute in order to prevent crashes when it is missing.

Environment:
- PHP: 8.3
- Bref: 2.3.4
- Laravel Bridge: 2.4.0