### PR TITLE
Fix support for Laravel 11

### DIFF
--- a/stubs/serverless.yml
+++ b/stubs/serverless.yml
@@ -7,6 +7,7 @@ provider:
     # Environment variables
     environment:
         APP_ENV: production # Or use ${sls:stage} if you want the environment to match the stage
+        SESSION_DRIVER: cookie # Change to database if you have set up a database
 
 package:
     # Files and directories to exclude from deployment


### PR DESCRIPTION
Fix #160 

I didn't want to fix that in the service provider because at this point it would get too magical (we can't just ignore the fact that the user could have explicitly configured the database).

Honestly I'm starting to think that we shouldn't change the config magically and instead rely on env variables (in the default serverless.yml template). We can't break BC, but maybe in the next major version we should simplify the bridge 🤷

WDYT?