### PR TITLE
Automatically install health checks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "php": "^8.0",
         "aws/aws-sdk-php": "^3.222",
         "bref/bref": "^2.1.8",
+        "bref/laravel-health-check": "^1",
         "illuminate/container": "^8.0 || ^9.0 || ^10.0 || ^11.0",
         "illuminate/contracts": "^8.0 || ^9.0 || ^10.0 || ^11.0",
         "illuminate/http": "^8.0 || ^9.0 || ^10.0 || ^11.0",


### PR DESCRIPTION
This is a package that adds Laravel health checks, these are used by bref.cloud to provide diagnostics (https://github.com/brefphp/laravel-health-check).

I created it as a separate package for now, we could merge here in the future but I'm thinking that a separate package might be easier to add advanced support for different Laravel versions (without impacting this one). However I want it installed by default so that there's no installation step for users. It doesn't do anything if you don't use it.