### PR TITLE
Only set aws tokens if a key is specified

### DIFF
--- a/src/BrefServiceProvider.php
+++ b/src/BrefServiceProvider.php
@@ -162,7 +162,7 @@ class BrefServiceProvider extends ServiceProvider
                 continue;
             }
             // If a different key is in the config than in the environment variables
-            if (isset($connection['key']) && $connection['key'] !== $accessKeyId) {
+            if (!isset($connection['key']) || $connection['key'] !== $accessKeyId) {
                 continue;
             }
 
@@ -175,7 +175,7 @@ class BrefServiceProvider extends ServiceProvider
                 continue;
             }
             // If a different key is in the config than in the environment variables
-            if (isset($disk['key']) && $disk['key'] !== $accessKeyId) {
+            if (!isset($disk['key']) || $disk['key'] !== $accessKeyId) {
                 continue;
             }
 
@@ -188,7 +188,7 @@ class BrefServiceProvider extends ServiceProvider
                 continue;
             }
             // If a different key is in the config than in the environment variables
-            if (isset($store['key']) && $store['key'] !== $accessKeyId) {
+            if (!isset($store['key']) || $store['key'] !== $accessKeyId) {
                 continue;
             }
 


### PR DESCRIPTION
https://github.com/laravel/framework/pull/53633 fixes the laravel side but it won't be patched into older versions

In sitiuations when no 'key' was specified only the 'token' was set causing invalid creds arrays to be generated