### PR TITLE
Handle 'common' web file MIME types

### DIFF
--- a/src/Http/Middleware/ServeStaticAssets.php
+++ b/src/Http/Middleware/ServeStaticAssets.php
@@ -43,12 +43,20 @@ class ServeStaticAssets
     protected function getMimeType(string $file)
     {
         $mimeType = finfo_file(finfo_open(FILEINFO_MIME_TYPE), $file);
-        $mimeType = strstr($mimeType, ';', true);
 
-        return str_replace(
-            ['image/vnd.microsoft.icon'],
-            ['image/x-icon'],
-            $mimeType
-        );
+        if ($mimeType === 'image/vnd.microsoft.icon') {
+            return 'image/x-icon';
+        }
+
+        if ($mimeType !== 'text/plain') {
+            return $mimeType;
+        }
+
+        return match (pathinfo($file, PATHINFO_EXTENSION)) {
+            'js' => 'text/javascript',
+            'css' => 'text/css',
+            'html' => 'text/html',
+            default => 'text/plain',
+        };
     }
 }


### PR DESCRIPTION
This handles serving 'common' (js, css, html) file types within the static assets middleware. The returned MIME type for these files is `text/plain` and based on this we attempt to determine the correct MIME type via their file extension. 

This is by no means an exhaustive list but provides support for files which would be typical for a web application.