### PR TITLE
make verbose job logging configurable but disable it by default

### DIFF
--- a/config/bref.php
+++ b/config/bref.php
@@ -41,5 +41,5 @@ return [
     |
     */
 
-    'jobs_logs' => false,
+    'log_jobs' => false,
 ];

--- a/config/bref.php
+++ b/config/bref.php
@@ -35,11 +35,9 @@ return [
     | Jobs Logging
     |--------------------------------------------------------------------------
     |
-    | Here you can enable detailed logging of every job execution for debugging
-    | purposes. Note, that enabling this, will result in a high volume of log
-    | entries.
+    | Here you can disable detailed logging of every job execution.
     |
     */
 
-    'log_jobs' => false,
+    'log_jobs' => true,
 ];

--- a/config/bref.php
+++ b/config/bref.php
@@ -30,4 +30,16 @@ return [
 
     'request_context' => false,
 
+    /*
+    |--------------------------------------------------------------------------
+    | Jobs Logging
+    |--------------------------------------------------------------------------
+    |
+    | Here you can enable detailed logging of every job execution for debugging
+    | purposes. Note, that enabling this, will result in a high volume of log
+    | entries.
+    |
+    */
+
+    'jobs_logs' => false,
 ];

--- a/src/BrefServiceProvider.php
+++ b/src/BrefServiceProvider.php
@@ -73,7 +73,7 @@ class BrefServiceProvider extends ServiceProvider
             ], 'bref-config');
         }
 
-        if (config('bref.jobs_logs', false)) {
+        if (config('bref.log_jobs', false)) {
             $this->enableDetailedJobLogging($dispatcher, $logManager, $queueFailer);
         }
 

--- a/src/BrefServiceProvider.php
+++ b/src/BrefServiceProvider.php
@@ -85,7 +85,11 @@ class BrefServiceProvider extends ServiceProvider
         }
     }
 
-    private function enableDetailedJobLogging(Dispatcher $dispatcher, LogManager $logManager, FailedJobProviderInterface $queueFailer): void {
+    private function enableDetailedJobLogging(
+        Dispatcher $dispatcher,
+        LogManager $logManager,
+        FailedJobProviderInterface $queueFailer
+    ): void {
         $dispatcher->listen(
             fn (JobProcessing $event) => $logManager->info(
                 "Processing job {$event->job->getJobId()}",

--- a/src/BrefServiceProvider.php
+++ b/src/BrefServiceProvider.php
@@ -73,7 +73,7 @@ class BrefServiceProvider extends ServiceProvider
             ], 'bref-config');
         }
 
-        if (config('bref.log_jobs', false)) {
+        if (config('bref.log_jobs', true)) {
             $this->enableDetailedJobLogging($dispatcher, $logManager, $queueFailer);
         }
 


### PR DESCRIPTION
This PR disables verbose logging about every job execution but, as proposed in #146. The verbose logging can still be enabled with the `bref.jobs_logs` configuration.

A logging of every single job execution does not provide any meaningful information, but rather renders logs useless, decreases performance and increases log storage costs.