### PR TITLE
Use PHP v8.2 as default

### DIFF
--- a/examples/getting-started/serverless.yml
+++ b/examples/getting-started/serverless.yml
@@ -60,7 +60,7 @@ functions:
       BREF_LOOP_MAX: 250
       BREF_BINARY_RESPONSES: 1
     layers:
-      - ${bref:layer.php-81}
+      - ${bref:layer.php-82}
     events:
       - httpApi: '*'
 
@@ -68,7 +68,7 @@ functions:
     handler: artisan
     timeout: 720
     layers:
-      - ${bref:layer.php-81}
+      - ${bref:layer.php-82}
       - ${bref:layer.console}
     events:
       - schedule:
@@ -79,7 +79,7 @@ functions:
     handler: Bref\LaravelBridge\Queue\QueueHandler
     timeout: 59
     layers:
-      - ${bref:layer.php-81}
+      - ${bref:layer.php-82}
     events:
       - sqs:
           arn: !GetAtt Queue.Arn

--- a/stubs/serverless.yml
+++ b/stubs/serverless.yml
@@ -24,7 +24,7 @@ functions:
     # This function runs the Laravel website/API
     web:
         handler: public/index.php
-        runtime: php-81-fpm
+        runtime: php-82-fpm
         timeout: 28 # in seconds (API Gateway has a timeout of 29 seconds)
         events:
             - httpApi: '*'
@@ -32,7 +32,7 @@ functions:
     # This function lets us run artisan commands in Lambda
     artisan:
         handler: artisan
-        runtime: php-81-console
+        runtime: php-82-console
         timeout: 720 # in seconds
         # Uncomment to also run the scheduler every minute
         #events:


### PR DESCRIPTION
Starting from L11, the required version of PHP is 8.2

<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->
