### PR TITLE
Overrides emergency logger if it is defaulted

### DIFF
--- a/src/BrefServiceProvider.php
+++ b/src/BrefServiceProvider.php
@@ -155,6 +155,10 @@ class BrefServiceProvider extends ServiceProvider
         if (Config::get('logging.default') === 'stack') {
             Config::set('logging.default', 'stderr');
         }
+
+        if (Config::get('logging.channels.emergency.path') === storage_path('logs/laravel.log')) {
+            Config::set('logging.channels.emergency', Config::get('logging.channels.stderr'));
+        }
     }
 
     private function fixAwsCredentialsConfig(): void


### PR DESCRIPTION
This overrides the emergency logger channel with the configuration for the stderr channel. 

Address issues where the emergency channel tries to throw exceptions, but cannot due to lack of storage with lambda.

This would address #176 

---
This pull request includes a change to the `fixDefaultConfiguration` method in the `src/BrefServiceProvider.php` file to handle the emergency logging channel configuration.

* [`src/BrefServiceProvider.php`](diffhunk://#diff-6888bb7b8ac364b842752c0f4d23a2e669b8dd5ad00f1aca21016df4f38c3779R158-R161): Added a condition to set the `logging.channels.emergency` configuration to `stderr` if the default path is `storage_path('logs/laravel.log')`.