### PR TITLE
Reset the scoped singleton for each job processing in the queue

### DIFF
--- a/src/Queue/QueueHandler.php
+++ b/src/Queue/QueueHandler.php
@@ -18,6 +18,7 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Cache\Repository as Cache;
+use Illuminate\Support\Facades\Facade;
 
 use Bref\LaravelBridge\MaintenanceMode;
 
@@ -71,6 +72,7 @@ class QueueHandler extends SqsHandler
      */
     public function handleSqs(SqsEvent $event, Context $context): void
     {
+        $app = $this->container;
         $resetScope = function () use ($app) {
             if (method_exists($app['log'], 'flushSharedContext')) {
                 $app['log']->flushSharedContext();
@@ -95,6 +97,7 @@ class QueueHandler extends SqsHandler
         /** @var Worker $worker */
         $worker = $this->container->makeWith(Worker::class, [
             'isDownForMaintenance' => fn () => MaintenanceMode::active(),
+            'resetScope' => $resetScope,
         ]);
 
         $worker->setCache(

--- a/src/Queue/Worker.php
+++ b/src/Queue/Worker.php
@@ -19,6 +19,10 @@ class Worker extends LaravelWorker
      */
     public function runSqsJob(Job $job, string $connectionName, WorkerOptions $options): void
     {
+        if (isset($this->resetScope)) {
+            ($this->resetScope)();
+        }
+
         pcntl_async_signals(true);
 
         pcntl_signal(SIGALRM, function () use ($job) {


### PR DESCRIPTION
This PR changes the behavior of the scoped singleton in the queue, raised in #177, from 'not being reset per job processing' to 'being reset'.