### PR TITLE
Update BrefServiceProvider.php

### DIFF
--- a/src/BrefServiceProvider.php
+++ b/src/BrefServiceProvider.php
@@ -170,6 +170,14 @@ class BrefServiceProvider extends ServiceProvider
             return;
         }
 
+        // Path Failed jobs for DynamoDB Driver
+        $failedConfig = Config::get('queue.failed');
+        if (
+            isset($failedConfig['driver']) && $failedConfig['driver'] === 'dynamodb' && $failedConfig['key'] === $accessKeyId
+        ) {
+            Config::set('queue.failed.token', $sessionToken);
+        }
+
         // Patch SQS config
         foreach (Config::get('queue.connections') as $name => $connection) {
             if ($connection['driver'] !== 'sqs') {


### PR DESCRIPTION
Adds patch for failed queue when using dynamodb driver for failed storage.

<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->
Sometimes we are using dynamodb for store failed jobs, when  using aws with serverless and temporary credentials you need to use the session token