### PR TITLE
Fix job retry: use the SQS queue URL instead of name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^8.2",
         "aws/aws-sdk-php": "^3.222",
-        "bref/bref": "^2.1.8 || ^3",
+        "bref/bref": "^3.0.2",
         "bref/laravel-health-check": "^1",
         "bref/monolog-bridge": "^1.0",
         "illuminate/container": "^10.0 || ^11.0 || ^12.0 || ^13.0",
@@ -21,12 +21,12 @@
         "illuminate/http": "^10.0 || ^11.0 || ^12.0 || ^13.0",
         "illuminate/queue": "^10.0 || ^11.0 || ^12.0 || ^13.0",
         "illuminate/support": "^10.0 || ^11.0 || ^12.0 || ^13.0",
-        "laravel/octane": "^1.2 || ^2.0 || dev-laravel13",
+        "laravel/octane": "^1.2 || ^2.0",
         "laravel/tinker": "^2.0 || ^3.0",
         "riverline/multipart-parser": "^2.0"
     },
     "require-dev": {
-        "larastan/larastan": "^2.11 || ^3 || dev-l13",
+        "larastan/larastan": "^2.11 || ^3",
         "orchestra/testbench": "^8.0 || ^9.0 || ^10.0 || ^11.0",
         "php-parallel-lint/php-parallel-lint": "^1.3",
         "phpunit/phpunit": "^9.5 || ^10 || ^11 || ^12.5.12",

--- a/src/Queue/QueueHandler.php
+++ b/src/Queue/QueueHandler.php
@@ -95,7 +95,7 @@ class QueueHandler extends SqsHandler
             $this->sqs,
             $message,
             $this->connection,
-            $sqsRecord->getQueueName(),
+            $sqsRecord->getQueueUrl(),
         );
     }
 


### PR DESCRIPTION
Without the URL the `queue:retry` command fails if the `SQS_PREFIX` is not defined (which is common).

Now retries will just work regardless.