### PR TITLE
Ensure stderr emergency logging

### DIFF
--- a/src/BrefServiceProvider.php
+++ b/src/BrefServiceProvider.php
@@ -184,9 +184,7 @@ class BrefServiceProvider extends ServiceProvider
             Config::set('logging.channels.stderr.formatter', CloudWatchFormatter::class);
         }
 
-        if (Config::get('logging.channels.emergency.path') === storage_path('logs/laravel.log')) {
-            Config::set('logging.channels.emergency', Config::get('logging.channels.stderr'));
-        }
+        Config::set('logging.channels.emergency', Config::get('logging.channels.stderr'));
     }
 
     private function fixAwsCredentialsConfig(): void

--- a/tests/BrefServiceProviderTest.php
+++ b/tests/BrefServiceProviderTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bref\LaravelBridge\Tests;
+
+use Bref\LaravelBridge\BrefServiceProvider;
+use Bref\LaravelBridge\StorageDirectories;
+use Bref\Monolog\CloudWatchFormatter;
+use Orchestra\Testbench\TestCase;
+
+class BrefServiceProviderTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $_SERVER['LAMBDA_TASK_ROOT'] = __DIR__;
+
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        unset($_SERVER['LAMBDA_TASK_ROOT']);
+
+        parent::tearDown();
+    }
+
+    public function testItUsesStderrForDefaultAndEmergencyLoggingOnLambda(): void
+    {
+        config()->set('logging.default', 'stack');
+        config()->set('logging.channels.stderr.formatter', null);
+        config()->set('logging.channels.emergency', [
+            'path' => '/custom/logs/laravel.log',
+        ]);
+
+        new BrefServiceProvider($this->app)->register();
+
+        $this->assertSame(StorageDirectories::Path, $this->app->storagePath());
+        $this->assertSame('stderr', config('logging.default'));
+        $this->assertSame(CloudWatchFormatter::class, config('logging.channels.stderr.formatter'));
+        $this->assertSame(config('logging.channels.stderr'), config('logging.channels.emergency'));
+    }
+}


### PR DESCRIPTION
This keeps Laravel’s default emergency logger aligned with the stderr channel after the bridge moves application storage to /tmp. The existing comparison checked the emergency log path after changing the storage path, so default Laravel emergency configuration could stay pointed at the read-only application directory and fail while reporting logger setup errors.