### PR TITLE
Ensure stderr emergency logging

### DIFF
--- a/config/bref.php
+++ b/config/bref.php
@@ -32,6 +32,23 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Logging
+    |--------------------------------------------------------------------------
+    |
+    | Lambda environments typically send logs to stderr rather than the local
+    | filesystem. These settings control Bref's Lambda logging behavior.
+    | Set either value to null to leave Laravel's logging configuration
+    | untouched.
+    |
+    */
+
+    'logging' => [
+        'default' => 'stderr',
+        'emergency_path' => 'php://stderr',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Jobs Logging
     |--------------------------------------------------------------------------
     |

--- a/config/bref.php
+++ b/config/bref.php
@@ -32,23 +32,6 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Logging
-    |--------------------------------------------------------------------------
-    |
-    | Lambda environments typically send logs to stderr rather than the local
-    | filesystem. These settings control Bref's Lambda logging behavior.
-    | Set either value to null to leave Laravel's logging configuration
-    | untouched.
-    |
-    */
-
-    'logging' => [
-        'default' => 'stderr',
-        'emergency_path' => 'php://stderr',
-    ],
-
-    /*
-    |--------------------------------------------------------------------------
     | Jobs Logging
     |--------------------------------------------------------------------------
     |

--- a/src/BrefServiceProvider.php
+++ b/src/BrefServiceProvider.php
@@ -41,11 +41,9 @@ class BrefServiceProvider extends ServiceProvider
             return;
         }
 
-        $defaultEmergencyPath = $this->app->storagePath('logs/laravel.log');
-
         $this->app->useStoragePath(StorageDirectories::Path);
 
-        $this->fixDefaultConfiguration($defaultEmergencyPath);
+        $this->fixDefaultConfiguration();
 
         Config::set('app.mix_url', Config::get('app.asset_url'));
 
@@ -172,7 +170,7 @@ class BrefServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    protected function fixDefaultConfiguration(string $defaultEmergencyPath)
+    protected function fixDefaultConfiguration()
     {
         if (Config::get('session.driver') === 'file') {
             Config::set('session.driver', 'cookie');

--- a/src/BrefServiceProvider.php
+++ b/src/BrefServiceProvider.php
@@ -176,21 +176,15 @@ class BrefServiceProvider extends ServiceProvider
             Config::set('session.driver', 'cookie');
         }
 
-        $defaultLogChannel = Config::get('bref.logging.default', 'stderr');
-
-        if ($defaultLogChannel !== null) {
-            Config::set('logging.default', $defaultLogChannel);
+        if (Config::get('logging.default') === 'stack') {
+            Config::set('logging.default', 'stderr');
         }
-
-        $defaultEmergencyChannelPath = Config::get('bref.logging.emergency_path', 'php://stderr');
 
         if (Config::get('logging.channels.stderr.formatter') === null) {
             Config::set('logging.channels.stderr.formatter', CloudWatchFormatter::class);
         }
 
-        if ($defaultEmergencyChannelPath !== null) {
-            Config::set('logging.channels.emergency.path', $defaultEmergencyChannelPath);
-        }
+        Config::set('logging.channels.emergency', Config::get('logging.channels.stderr'));
     }
 
     private function fixAwsCredentialsConfig(): void

--- a/src/BrefServiceProvider.php
+++ b/src/BrefServiceProvider.php
@@ -184,9 +184,7 @@ class BrefServiceProvider extends ServiceProvider
             Config::set('logging.channels.stderr.formatter', CloudWatchFormatter::class);
         }
 
-        if (Config::get('logging.channels.emergency.path') === storage_path('logs/laravel.log')) {
-            Config::set('logging.channels.emergency', Config::get('logging.channels.stderr'));
-        }
+        Config::set('logging.channels.emergency', Config::get('logging.channels.stderr'));
     }
 
     private function fixAwsCredentialsConfig(): void

--- a/src/BrefServiceProvider.php
+++ b/src/BrefServiceProvider.php
@@ -41,9 +41,11 @@ class BrefServiceProvider extends ServiceProvider
             return;
         }
 
+        $defaultEmergencyPath = $this->app->storagePath('logs/laravel.log');
+
         $this->app->useStoragePath(StorageDirectories::Path);
 
-        $this->fixDefaultConfiguration();
+        $this->fixDefaultConfiguration($defaultEmergencyPath);
 
         Config::set('app.mix_url', Config::get('app.asset_url'));
 
@@ -170,7 +172,7 @@ class BrefServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    protected function fixDefaultConfiguration()
+    protected function fixDefaultConfiguration(string $defaultEmergencyPath)
     {
         if (Config::get('session.driver') === 'file') {
             Config::set('session.driver', 'cookie');
@@ -184,7 +186,9 @@ class BrefServiceProvider extends ServiceProvider
             Config::set('logging.channels.stderr.formatter', CloudWatchFormatter::class);
         }
 
-        Config::set('logging.channels.emergency', Config::get('logging.channels.stderr'));
+        if (Config::get('logging.channels.emergency.path') === $defaultEmergencyPath) {
+            Config::set('logging.channels.emergency.path', 'php://stderr');
+        }
     }
 
     private function fixAwsCredentialsConfig(): void

--- a/src/BrefServiceProvider.php
+++ b/src/BrefServiceProvider.php
@@ -178,16 +178,20 @@ class BrefServiceProvider extends ServiceProvider
             Config::set('session.driver', 'cookie');
         }
 
-        if (Config::get('logging.default') === 'stack') {
-            Config::set('logging.default', 'stderr');
+        $defaultLogChannel = Config::get('bref.logging.default', 'stderr');
+
+        if ($defaultLogChannel !== null) {
+            Config::set('logging.default', $defaultLogChannel);
         }
+
+        $defaultEmergencyChannelPath = Config::get('bref.logging.emergency_path', 'php://stderr');
 
         if (Config::get('logging.channels.stderr.formatter') === null) {
             Config::set('logging.channels.stderr.formatter', CloudWatchFormatter::class);
         }
 
-        if (Config::get('logging.channels.emergency.path') === $defaultEmergencyPath) {
-            Config::set('logging.channels.emergency.path', 'php://stderr');
+        if ($defaultEmergencyChannelPath !== null) {
+            Config::set('logging.channels.emergency.path', $defaultEmergencyChannelPath);
         }
     }
 

--- a/tests/BrefServiceProviderTest.php
+++ b/tests/BrefServiceProviderTest.php
@@ -31,7 +31,7 @@ class BrefServiceProviderTest extends TestCase
 
     public function testItUsesStderrForDefaultEmergencyLoggingOnLambda(): void
     {
-        config()->set('logging.default', 'stack');
+        config()->set('logging.default', 'single');
         config()->set('logging.channels.stderr.formatter', null);
         config()->set('logging.channels.emergency', [
             'path' => $this->defaultEmergencyPath,
@@ -45,11 +45,56 @@ class BrefServiceProviderTest extends TestCase
         $this->assertSame('php://stderr', config('logging.channels.emergency.path'));
     }
 
-    public function testItPreservesCustomEmergencyLoggingPathOnLambda(): void
+    public function testItUsesConfiguredBrefLoggingOverridesOnLambda(): void
     {
+        config()->set('bref.logging.default', 'errorlog');
+        config()->set('bref.logging.emergency_path', '/tmp/bref-emergency.log');
+        config()->set('logging.default', 'daily');
+        config()->set('logging.channels.emergency', [
+            'path' => $this->defaultEmergencyPath,
+        ]);
+
+        (new BrefServiceProvider($this->app))->register();
+
+        $this->assertSame('errorlog', config('logging.default'));
+        $this->assertSame('/tmp/bref-emergency.log', config('logging.channels.emergency.path'));
+    }
+
+    public function testItCanOptOutOfBrefLoggingOverridesOnLambda(): void
+    {
+        config()->set('bref.logging.default', null);
+        config()->set('bref.logging.emergency_path', null);
+        config()->set('logging.default', 'daily');
+        config()->set('logging.channels.emergency', [
+            'path' => $this->defaultEmergencyPath,
+        ]);
+
+        (new BrefServiceProvider($this->app))->register();
+
+        $this->assertSame('daily', config('logging.default'));
+        $this->assertSame($this->defaultEmergencyPath, config('logging.channels.emergency.path'));
+    }
+
+    public function testItOverridesCustomEmergencyLoggingPathOnLambda(): void
+    {
+        config()->set('bref.logging.emergency_path', '/tmp/bref-emergency.log');
         config()->set('logging.channels.emergency', [
             'path' => '/tmp/emergency.log',
         ]);
+
+        (new BrefServiceProvider($this->app))->register();
+
+        $this->assertSame('/tmp/bref-emergency.log', config('logging.channels.emergency.path'));
+    }
+
+    public function testItCanOptOutOfEmergencyOverrideForCustomPathOnLambda(): void
+    {
+        config()->set('bref.logging.emergency_path', null);
+        config()->set('logging.channels.emergency', [
+            'path' => '/tmp/emergency.log',
+        ]);
+
+        $this->app->useStoragePath('/tmp/custom-storage');
 
         (new BrefServiceProvider($this->app))->register();
 

--- a/tests/BrefServiceProviderTest.php
+++ b/tests/BrefServiceProviderTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bref\LaravelBridge\Tests;
+
+use Bref\LaravelBridge\BrefServiceProvider;
+use Bref\LaravelBridge\StorageDirectories;
+use Bref\Monolog\CloudWatchFormatter;
+use Orchestra\Testbench\TestCase;
+
+class BrefServiceProviderTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $_SERVER['LAMBDA_TASK_ROOT'] = __DIR__;
+
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        unset($_SERVER['LAMBDA_TASK_ROOT']);
+
+        parent::tearDown();
+    }
+
+    public function testItUsesStderrForDefaultAndEmergencyLoggingOnLambda(): void
+    {
+        config()->set('logging.default', 'stack');
+        config()->set('logging.channels.stderr.formatter', null);
+        config()->set('logging.channels.emergency', [
+            'path' => '/custom/logs/laravel.log',
+        ]);
+
+        new BrefServiceProvider($this->app)->register();
+
+        $this->assertSame(StorageDirectories::Path, $this->app->storagePath());
+        $this->assertSame('stderr', config('logging.default'));
+        $this->assertSame(CloudWatchFormatter::class, config('logging.channels.stderr.formatter'));
+        $this->assertSame(config('logging.channels.stderr'), config('logging.channels.emergency'));
+    }
+}

--- a/tests/BrefServiceProviderTest.php
+++ b/tests/BrefServiceProviderTest.php
@@ -11,11 +11,15 @@ use Orchestra\Testbench\TestCase;
 
 class BrefServiceProviderTest extends TestCase
 {
+    private string $defaultEmergencyPath;
+
     protected function setUp(): void
     {
         $_SERVER['LAMBDA_TASK_ROOT'] = __DIR__;
 
         parent::setUp();
+
+        $this->defaultEmergencyPath = $this->app->storagePath('logs/laravel.log');
     }
 
     protected function tearDown(): void
@@ -25,19 +29,30 @@ class BrefServiceProviderTest extends TestCase
         parent::tearDown();
     }
 
-    public function testItUsesStderrForDefaultAndEmergencyLoggingOnLambda(): void
+    public function testItUsesStderrForDefaultEmergencyLoggingOnLambda(): void
     {
         config()->set('logging.default', 'stack');
         config()->set('logging.channels.stderr.formatter', null);
         config()->set('logging.channels.emergency', [
-            'path' => '/custom/logs/laravel.log',
+            'path' => $this->defaultEmergencyPath,
         ]);
 
-        new BrefServiceProvider($this->app)->register();
+        (new BrefServiceProvider($this->app))->register();
 
         $this->assertSame(StorageDirectories::Path, $this->app->storagePath());
         $this->assertSame('stderr', config('logging.default'));
         $this->assertSame(CloudWatchFormatter::class, config('logging.channels.stderr.formatter'));
-        $this->assertSame(config('logging.channels.stderr'), config('logging.channels.emergency'));
+        $this->assertSame('php://stderr', config('logging.channels.emergency.path'));
+    }
+
+    public function testItPreservesCustomEmergencyLoggingPathOnLambda(): void
+    {
+        config()->set('logging.channels.emergency', [
+            'path' => '/tmp/emergency.log',
+        ]);
+
+        (new BrefServiceProvider($this->app))->register();
+
+        $this->assertSame('/tmp/emergency.log', config('logging.channels.emergency.path'));
     }
 }

--- a/tests/BrefServiceProviderTest.php
+++ b/tests/BrefServiceProviderTest.php
@@ -66,38 +66,12 @@ class BrefServiceProviderTest extends TestCase
         config()->set('bref.logging.emergency_path', null);
         config()->set('logging.default', 'daily');
         config()->set('logging.channels.emergency', [
-            'path' => $this->defaultEmergencyPath,
+            'path' => '/tmp/emergency.log',
         ]);
 
         (new BrefServiceProvider($this->app))->register();
 
         $this->assertSame('daily', config('logging.default'));
-        $this->assertSame($this->defaultEmergencyPath, config('logging.channels.emergency.path'));
-    }
-
-    public function testItOverridesCustomEmergencyLoggingPathOnLambda(): void
-    {
-        config()->set('bref.logging.emergency_path', '/tmp/bref-emergency.log');
-        config()->set('logging.channels.emergency', [
-            'path' => '/tmp/emergency.log',
-        ]);
-
-        (new BrefServiceProvider($this->app))->register();
-
-        $this->assertSame('/tmp/bref-emergency.log', config('logging.channels.emergency.path'));
-    }
-
-    public function testItCanOptOutOfEmergencyOverrideForCustomPathOnLambda(): void
-    {
-        config()->set('bref.logging.emergency_path', null);
-        config()->set('logging.channels.emergency', [
-            'path' => '/tmp/emergency.log',
-        ]);
-
-        $this->app->useStoragePath('/tmp/custom-storage');
-
-        (new BrefServiceProvider($this->app))->register();
-
         $this->assertSame('/tmp/emergency.log', config('logging.channels.emergency.path'));
     }
 }

--- a/tests/BrefServiceProviderTest.php
+++ b/tests/BrefServiceProviderTest.php
@@ -11,15 +11,11 @@ use Orchestra\Testbench\TestCase;
 
 class BrefServiceProviderTest extends TestCase
 {
-    private string $defaultEmergencyPath;
-
     protected function setUp(): void
     {
         $_SERVER['LAMBDA_TASK_ROOT'] = __DIR__;
 
         parent::setUp();
-
-        $this->defaultEmergencyPath = $this->app->storagePath('logs/laravel.log');
     }
 
     protected function tearDown(): void
@@ -29,12 +25,12 @@ class BrefServiceProviderTest extends TestCase
         parent::tearDown();
     }
 
-    public function testItUsesStderrForDefaultEmergencyLoggingOnLambda(): void
+    public function testItUsesStderrForDefaultAndEmergencyLoggingOnLambda(): void
     {
-        config()->set('logging.default', 'single');
+        config()->set('logging.default', 'stack');
         config()->set('logging.channels.stderr.formatter', null);
         config()->set('logging.channels.emergency', [
-            'path' => $this->defaultEmergencyPath,
+            'path' => '/custom/logs/laravel.log',
         ]);
 
         (new BrefServiceProvider($this->app))->register();
@@ -42,36 +38,6 @@ class BrefServiceProviderTest extends TestCase
         $this->assertSame(StorageDirectories::Path, $this->app->storagePath());
         $this->assertSame('stderr', config('logging.default'));
         $this->assertSame(CloudWatchFormatter::class, config('logging.channels.stderr.formatter'));
-        $this->assertSame('php://stderr', config('logging.channels.emergency.path'));
-    }
-
-    public function testItUsesConfiguredBrefLoggingOverridesOnLambda(): void
-    {
-        config()->set('bref.logging.default', 'errorlog');
-        config()->set('bref.logging.emergency_path', '/tmp/bref-emergency.log');
-        config()->set('logging.default', 'daily');
-        config()->set('logging.channels.emergency', [
-            'path' => $this->defaultEmergencyPath,
-        ]);
-
-        (new BrefServiceProvider($this->app))->register();
-
-        $this->assertSame('errorlog', config('logging.default'));
-        $this->assertSame('/tmp/bref-emergency.log', config('logging.channels.emergency.path'));
-    }
-
-    public function testItCanOptOutOfBrefLoggingOverridesOnLambda(): void
-    {
-        config()->set('bref.logging.default', null);
-        config()->set('bref.logging.emergency_path', null);
-        config()->set('logging.default', 'daily');
-        config()->set('logging.channels.emergency', [
-            'path' => '/tmp/emergency.log',
-        ]);
-
-        (new BrefServiceProvider($this->app))->register();
-
-        $this->assertSame('daily', config('logging.default'));
-        $this->assertSame('/tmp/emergency.log', config('logging.channels.emergency.path'));
+        $this->assertSame(config('logging.channels.stderr'), config('logging.channels.emergency'));
     }
 }


### PR DESCRIPTION
Back to the original fix from #202…

This keeps Laravel’s default emergency logger aligned with the stderr channel after the bridge moves application storage to `/tmp`.

The existing comparison checked the emergency log path after changing the storage path, so default Laravel emergency configuration could stay pointed at the read-only application directory and fail while reporting logger setup errors.