### PR TITLE
Add `fonts-manifest.json` to `serverless.yml` for Laravel 13

### DIFF
--- a/stubs/serverless.yml
+++ b/stubs/serverless.yml
@@ -123,9 +123,10 @@ package:
         - '!storage/**'
         - '!tests/**'
         - '!database/*.sqlite'
-        # Exclude assets except for the manifest file
+        # Exclude assets except for the manifest files
         - '!public/build/**'
         - 'public/build/manifest.json'
+        - 'public/build/fonts-manifest.json'
 
 plugins:
     # We need to include the Bref plugin


### PR DESCRIPTION
Laravel 13 adds an optional `fonts-manifest.json` file.