### PR TITLE
Add font files to `serverless.yml` for Laravel 13

### DIFF
--- a/stubs/serverless.yml
+++ b/stubs/serverless.yml
@@ -127,6 +127,7 @@ package:
         - '!public/build/**'
         - 'public/build/manifest.json'
         - 'public/build/fonts-manifest.json'
+        - 'public/build/assets/fonts-*.css'
 
 plugins:
     # We need to include the Bref plugin


### PR DESCRIPTION
Follow-up of #208 as these files are read by PHP too.